### PR TITLE
Add Vercel Analytics for lightweight page tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.78.0",
         "@prisma/client": "^6.19.2",
+        "@vercel/analytics": "^1.6.1",
         "cheerio": "^1.1.2",
         "googleapis": "^171.4.0",
         "next": "16.1.3",
@@ -2788,6 +2789,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@prisma/client": "^6.19.2",
+    "@vercel/analytics": "^1.6.1",
     "cheerio": "^1.1.2",
     "googleapis": "^171.4.0",
     "next": "16.1.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -82,6 +83,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-stone-50 min-h-screen`}
       >
         {children}
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Integrated Vercel Analytics for privacy-friendly, cookieless analytics
- Tracks page views, referrers, and Web Vitals automatically

## Details

Added `@vercel/analytics` to provide lightweight analytics tracking without cookies or privacy concerns.

**Key Features:**
- 🪶 Lightweight (~1KB bundle size)
- 🔒 Privacy-friendly (no cookies, GDPR compliant)
- 📊 Automatic Web Vitals tracking
- 🎯 Page views and referrer tracking
- 📱 Built-in Vercel dashboard integration

**What it tracks:**
- Page views
- Referrers
- Top pages
- Geographic location (country level)
- Web Vitals (LCP, FID, CLS)

**What it doesn't track:**
- No cookies
- No personal data
- No cross-site tracking

## Implementation
Simply added the `<Analytics />` component to the root layout. Analytics will automatically start collecting data once deployed to Vercel.

## Test plan
- [ ] Verify build passes
- [ ] Deploy to production
- [ ] Check Vercel dashboard for analytics data after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)