### PR TITLE
Enhance email scraper to extract event URLs and images

### DIFF
--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -24,7 +24,7 @@ Extract event information from emails and return structured JSON.
 - endDate: ISO 8601 datetime
 - address: Street address
 - price: Price string (e.g., "$20", "Free", "$15-$30")
-- imageUrl: Image URL from email
+- imageUrl: Image URL for event poster/photo
 - eventUrl: URL for event registration, tickets, or more info
 
 **Rules:**
@@ -49,7 +49,18 @@ Extract event information from emails and return structured JSON.
    - "$15-$30" → "$15-$30"
    - "Donation" → "Donation"
 
-6. Extract image URLs from <img> tags if present
+6. **IMPORTANT - Extract URLs from email:**
+   - eventUrl: Look for event registration/ticket/info links
+     * Eventbrite, Ticketmaster, Facebook Events, Meetup
+     * Venue websites with event details
+     * "Register here", "Buy tickets", "More info", "RSVP"
+     * RunSignUp, ShowClix, TicketWeb, Dice.fm
+     * Any clickable link related to the event
+   - imageUrl: Extract event poster/photo URLs
+     * From <img> tags (src attribute)
+     * From direct image links (ending in .jpg, .png, .webp, etc.)
+     * Choose the most relevant/largest event image
+     * Prefer event posters over logos or decorative images
 
 7. Return array of events (empty array if none found)
 


### PR DESCRIPTION
## Summary
- Enhanced AI prompt to better extract event URLs and image URLs from email newsletters
- Added specific instructions for finding registration/ticketing links (Eventbrite, Ticketmaster, Facebook Events, etc.)
- Improved image URL extraction to identify event posters from img tags and direct links
- Prioritizes relevant event images over logos or decorative images

## What Changed
Updated the email extraction system prompt in `src/lib/ai/prompts.ts` to be more explicit about:
- **eventUrl extraction**: Looks for registration, ticketing, and event info links from various platforms
- **imageUrl extraction**: Finds event posters from HTML img tags and direct image links, prioritizing relevant event images

## Test Plan
- [ ] Run email scraper on test newsletters with event URLs
- [ ] Verify extracted events have proper eventUrl field populated
- [ ] Verify extracted events have imageUrl field populated when images are present
- [ ] Test that events are clickable and link to the correct event pages

## Context
Fixes #32 - Events from email scraper now have URLs attached so they link somewhere when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)