### PR TITLE
feat: Marquee events carousel and filter

### DIFF
--- a/activities-research.md
+++ b/activities-research.md
@@ -1,0 +1,339 @@
+# Always-Available Activities for Nyack Today
+
+Research compilation for populating the Activity database model with permanent attractions, recreation facilities, parks, and cultural venues in Nyack, Upper Nyack, South Nyack, and nearby West Nyack.
+
+---
+
+## SPORTS & RECREATION
+
+### Rockland Lake State Park
+- **Venue:** Rockland Lake State Park
+- **Address:** 299 Rockland Lake Rd, Valley Cottage, NY 10989
+- **City:** Valley Cottage
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** 1,133-acre park featuring a 3.2-mile paved trail around the lake, two Olympic-sized swimming pools, 25,000 sq ft zero-entry pool with water slides, two 18-hole golf courses (Championship and Executive), six tennis courts, pickleball, car-top boat launch, fishing, cross-country skiing, sledding, playground, and picnic areas with grills.
+- **Hours:** Dawn to dusk (pool and facilities vary by season)
+- **Price:** Free entry, parking fee $8-10, pool admission varies
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://parks.ny.gov/visit/state-parks/rockland-lake-state-park
+- **Sources:** [Rockland Lake State Park](https://parks.ny.gov/visit/state-parks/rockland-lake-state-park), [Palisades Parks Conservancy](https://www.palisadesparks.org/rockland-lake)
+
+---
+
+### Nyack Beach State Park
+- **Venue:** Nyack Beach State Park
+- **Address:** 663 N Broadway, Upper Nyack, NY 10960
+- **City:** Upper Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** 61-acre riverfront park along the Hudson River offering picnicking, hiking, bicycling, fishing, kayak/windsurfer launching, and cross-country skiing in winter. Southern terminus of the Hudson River Greenway Trail. One of the best hawk and raptor viewing areas in the U.S.
+- **Hours:** Dawn to dusk, year-round
+- **Price:** Free entry, parking fee $8-10
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://parks.ny.gov/visit/state-parks/nyack-beach-state-park
+- **Sources:** [Nyack Beach State Park](https://parks.ny.gov/visit/state-parks/nyack-beach-state-park), [Palisades Parks Conservancy](https://www.palisadesparks.org/nyack-beach)
+
+---
+
+### Memorial Park
+- **Venue:** Nyack Memorial Park
+- **Address:** On the Hudson River waterfront, Nyack, NY 10960
+- **City:** Nyack
+- **isNyackProper:** true
+- **Category:** SPORTS_RECREATION
+- **Description:** 11-acre waterfront park featuring baseball field, basketball courts, children's playground, skateboard park, and splash pad. Hosts community events like the Great Nyack Get Together and summer concert series "Music on the Hudson."
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://visitnyack.org/memorial-park/
+- **Sources:** [Visit Nyack - Memorial Park](https://visitnyack.org/memorial-park/), [Nyack Parks](https://www.nyack.gov/maps/Parks)
+
+---
+
+### Hook Mountain State Park
+- **Venue:** Hook Mountain State Park
+- **Address:** Upper Nyack, NY 10960 (access via Upper Nyack Trail)
+- **City:** Upper Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Part of a 2,000-acre connected park system. Features the popular Hook Mountain and Nyack Beach Loop trail (5.9 miles, moderate difficulty, 1,023 ft elevation gain). Summit at 730 feet offers spectacular Hudson River valley views, historic Knickerbocker Ice House ruins, and excellent bird watching.
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://parks.ny.gov/parks/hookmountain
+- **Sources:** [AllTrails - Hook Mountain](https://www.alltrails.com/trail/us/new-york/hook-mountain-nyack-beach-loop), [Scenes from the Trail](https://scenesfromthetrail.com/2022/07/20/hook-mountain-summit-via-upper-nyack-trail-long-path/)
+
+---
+
+### Tallman Mountain State Park
+- **Venue:** Tallman Mountain State Park
+- **Address:** 9 S Route 9W, Palisades, NY 10964
+- **City:** Palisades
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Features the Tallman Mountain Hudson River Overlook Trail (3.7 miles, 301 ft elevation gain). Offers stunning views of the Hudson River and Piermont Marsh, part of the Hudson River National Estuarine Research Reserve. Great for hiking, bird watching, and nature photography.
+- **Hours:** Dawn to dusk
+- **Price:** Free entry, parking fee varies
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://parks.ny.gov/parks/tallmanmountain
+- **Sources:** [AllTrails - Tallman Mountain](https://www.alltrails.com/parks/us/new-york/tallman-mountain-state-park)
+
+---
+
+### South Nyack Park
+- **Venue:** South Nyack Park
+- **Address:** Near South Nyack Fire House, South Nyack, NY 10960
+- **City:** South Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Fully gated playground for kids, gazebo with live music in summertime, enclosed tennis court, basketball court, and entrance to the Esposito Trail which connects to Piermont. Family-friendly neighborhood park.
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://www.nyack.gov/maps/Parks
+- **Sources:** Search results from local parks directory
+
+---
+
+### Franklin Street Park
+- **Venue:** Franklin Street Park
+- **Address:** 95 South Franklin Street, South Nyack, NY 10960
+- **City:** South Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Gated playground with firehouse-themed equipment, two metal climbing structures outside the enclosed area, basketball court, tennis court, picnic tables, gazebo with live music in summertime, drinking water, and access to the Esposito Trail to Piermont. Located next to South Nyack fire house.
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://visitnyack.org/places/franklin-street-park/
+- **Sources:** [Visit Nyack - Franklin Street Park](https://visitnyack.org/places/franklin-street-park/), [Franklin Street Park - Been There Done That Trips](https://beentheredonethattrips.com/franklin-street-park-nyack-ny/)
+
+---
+
+### Raymond G. Esposito Memorial Trail
+- **Venue:** Raymond G. Esposito Memorial Trail
+- **Address:** Begins in South Nyack, extends to Piermont
+- **City:** South Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Multi-use rail trail connecting South Nyack to Piermont (approximately 3 miles). Perfect for walking, jogging, and biking. Connects to the Joseph B. Clarke Rail Trail and Old Erie Path. Offers Hudson River views and access to downtown Nyack and Piermont Pier.
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://www.traillink.com/trail/joseph-b-clarke-rail-trail/
+- **Sources:** [AllTrails - Esposito Trail](https://www.alltrails.com/trail/us/new-york/raymond-g-esposito-trail), [Historic Hudson River Towns](https://www.hudsonriver.com/hhrt/find-your-path/piermont-piermont-pier/)
+
+---
+
+### Piermont Pier
+- **Venue:** Piermont Pier
+- **Address:** End of Piermont Avenue, Piermont, NY 10968
+- **City:** Piermont
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Nearly mile-long (4,000 feet) pier extending into the Hudson River. Walk, jog, bike, or drive on this historic structure. Former Erie Railroad terminus from the mid-1800s and WWII "Last Stop USA" embarkation point. Stunning river views, fishing, and bird watching.
+- **Hours:** Dawn to dusk
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://www.piermont-ny.gov/services/visitors.php
+- **Sources:** [Historic Hudson River Towns - Piermont Pier](https://www.hudsonriver.com/hhrt/find-your-path/piermont-piermont-pier/), [Nyack News & Views](https://nyacknewsandviews.com/blog/2021/09/roaming-rockland-piermont-pier/)
+
+---
+
+### Nyack Marina
+- **Venue:** Nyack Marina
+- **Address:** End of Burd Street, Nyack, NY 10960
+- **City:** Nyack
+- **isNyackProper:** true
+- **Category:** SPORTS_RECREATION
+- **Description:** Village-owned marina offering public boat launch, seasonal slip rentals, kayak storage racks, and kayak launching. Part of the Hudson River Greenways water trail. Short walk from downtown shops and restaurants.
+- **Hours:** Dawn to dusk (seasonal)
+- **Price:** Daily parking/launch fees apply
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** Contact: parking@nyack-ny.gov
+- **Sources:** [Visit Nyack - Hudson River Boating](https://visitnyack.org/hudson-river-boating-nyack/), [Hudson River Guide](https://www.riverexplorer.com/hudson/details.php?id=3335)
+
+---
+
+### K1 Speed Indoor Go-Karts
+- **Venue:** K1 Speed West Nyack
+- **Address:** 2272 Palisades Center Dr (2nd floor), West Nyack, NY 10994
+- **City:** West Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Indoor electric go-kart racing on professionally designed track. All-electric karts reach speeds up to 45 mph. Pro Karts for ages 13+ (56" tall), Jr Karts for ages 8+ (48" tall). Family entertainment center inside Palisades Center Mall.
+- **Hours:** Mon-Sun 11:00 AM - 7:00 PM (check website for current hours)
+- **Price:** Varies by race package
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://www.k1speed.com/west-nyack-location.html
+- **Sources:** [K1 Speed West Nyack](https://www.k1speed.com/west-nyack-location.html), [Yelp](https://www.yelp.com/biz/k1-speed-west-nyack)
+
+---
+
+### Palisades Center Ice Rink
+- **Venue:** Palisades Center Ice Rink
+- **Address:** 4900 Palisades Center Dr, West Nyack, NY 10994
+- **City:** West Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** Indoor ice skating rink offering public skating sessions, skating lessons, and Learn to Skate programs. Located inside Palisades Center Mall. Family-friendly recreational skating year-round.
+- **Hours:** Mon-Sun 11:00 AM - 7:00 PM (public sessions vary - check website)
+- **Price:** Admission and skate rental fees apply
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://palisadescentericerink.com/
+- **Phone:** (845) 353-4855
+- **Sources:** [Palisades Center Ice Rink](https://palisadescentericerink.com/), [Yelp](https://www.yelp.com/biz/palisades-center-ice-rink-west-nyack)
+
+---
+
+### Rockland County YMCA
+- **Venue:** Rockland County YMCA
+- **Address:** 35 South Broadway, Nyack, NY 10960
+- **City:** Nyack
+- **isNyackProper:** true
+- **Category:** SPORTS_RECREATION
+- **Description:** Full-service fitness center featuring gym, pool, weight room, sauna, whirlpool, and multi-purpose room. Offers fitness classes, swimming programs, and community wellness activities. Membership-based facility.
+- **Hours:** Varies by day (check website)
+- **Price:** Membership required
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://www.rocklandymca.org/main/nyack-health-fitness/
+- **Sources:** [Rockland County YMCA](https://www.rocklandymca.org/main/nyack-health-fitness/)
+
+---
+
+## ART & CULTURE
+
+### Edward Hopper House Museum & Study Center
+- **Venue:** Edward Hopper House Museum & Study Center
+- **Address:** 82 North Broadway, Nyack, NY 10960
+- **City:** Nyack
+- **isNyackProper:** true
+- **Category:** ART_GALLERIES
+- **Description:** Birthplace and boyhood home of renowned American artist Edward Hopper (1882-1967). Built in 1858, now a museum and community art center. Features rotating exhibitions, Hopper's first studio, early artworks, model boats, and memorabilia. Listed on the National Register of Historic Places. Celebrating 55th anniversary in 2026.
+- **Hours:** Thu-Sun 12:00 PM - 5:00 PM
+- **Price:** Suggested donation
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://www.edwardhopperhouse.org/
+- **Sources:** [Edward Hopper House Museum](https://www.edwardhopperhouse.org/), [Visit Nyack](https://visitnyack.org/places/edward-hopper-house-museum-and-study-center/)
+
+---
+
+### Nyack Library
+- **Venue:** Nyack Library
+- **Address:** 59 S Broadway, Nyack, NY 10960
+- **City:** Nyack
+- **isNyackProper:** true
+- **Category:** COMMUNITY_GOVERNMENT
+- **Description:** Free association library offering language classes, cooking sessions, art workshops, music gatherings, storytime for children, virtual author talks, book discussion groups, and museum pass borrowing. Ample parking and quiet study spaces available.
+- **Hours:** Mon 11am-8pm, Tue-Thu 10am-8pm, Fri 10am-6pm, Sat 10am-5pm, Sun 12pm-5pm
+- **Price:** Free
+- **isFree:** true
+- **isFamilyFriendly:** true
+- **Website:** https://www.nyacklibrary.org/
+- **Phone:** (845) 358-3370
+- **Sources:** [Nyack Library](https://www.nyacklibrary.org/), [Yelp](https://www.yelp.com/biz/the-nyack-library-nyack)
+
+---
+
+## MOVIES & ENTERTAINMENT
+
+### AMC Palisades 21
+- **Venue:** AMC Palisades 21
+- **Address:** 4403 Palisades Ctr Dr, West Nyack, NY 10994
+- **City:** West Nyack
+- **isNyackProper:** false
+- **Category:** MOVIES
+- **Description:** 21-screen movie theater featuring IMAX and REAL-D 3D. Premium amenities include reclining seats, reserved seating, mobile food ordering, assisted listening devices, and wheelchair access. $5 ticket Tuesdays.
+- **Hours:** Mon-Sun 11:00 AM - 11:00 PM (showtimes vary)
+- **Price:** Varies by showtime; $5 on Tuesdays
+- **isFree:** false
+- **isFamilyFriendly:** true
+- **Website:** https://www.amctheatres.com/movie-theatres/west-nyack/amc-palisades-21
+- **Phone:** (845) 348-1876
+- **Sources:** [AMC Palisades 21](https://www.amctheatres.com/movie-theatres/west-nyack/amc-palisades-21), [Yelp](https://www.yelp.com/biz/amc-palisades-21-west-nyack)
+
+---
+
+## ADDITIONAL PALISADES CENTER ATTRACTIONS
+
+### Palisades Climb Adventure
+- **Venue:** Palisades Climb Adventure
+- **Address:** Palisades Center Mall, West Nyack, NY 10994
+- **City:** West Nyack
+- **isNyackProper:** false
+- **Category:** SPORTS_RECREATION
+- **Description:** World's tallest indoor ropes course at 85 feet. Challenging multi-level climbing adventure with various obstacles and zip lines. Safety equipment and instruction provided.
+- **Hours:** Varies (check mall website)
+- **Price:** Admission fees apply
+- **isFree:** false
+- **isFamilyFriendly:** true (age/height restrictions apply)
+- **Website:** https://palisadescenter.com/
+- **Sources:** [Palisades Center](https://palisadescenter.com/post/6-fun-safe-winter-break-activities-at-palisades-center/), [Mommy Poppins](https://mommypoppins.com/kids/the-palisades-center-mall-with-kids)
+
+---
+
+
+## NOTES FOR DATABASE POPULATION
+
+**Categories Used:**
+- SPORTS_RECREATION: Parks, trails, gyms, go-karts, ice skating, bowling, climbing
+- ART_GALLERIES: Edward Hopper House Museum
+- COMMUNITY_GOVERNMENT: Nyack Library
+- MOVIES: AMC Palisades 21
+
+**Distance Considerations:**
+- Nyack proper: ~7,400 population
+- Upper Nyack, South Nyack: Adjacent communities
+- West Nyack (Palisades Center): ~5 miles from downtown Nyack, 10-minute drive
+- Valley Cottage (Rockland Lake): ~3 miles from Nyack
+- Piermont: ~3 miles south of Nyack, connected by trail
+
+**Family-Friendly Indicators:**
+- Most outdoor parks and trails: true
+- Libraries, playgrounds: true
+- Go-karts, ice skating: true (with age/height restrictions)
+- Museums: true
+- Gyms with membership: generally true (family programs available)
+
+**Price Indicators:**
+- State parks: Free entry but parking fees ($8-10)
+- Libraries: Free
+- Commercial entertainment (go-karts, bowling, movies): Paid admission
+- Trails and public parks: Free
+- Museums: Suggested donation or modest admission
+
+---
+
+## SOURCES
+
+- [Nyack Beach State Park](https://parks.ny.gov/visit/state-parks/nyack-beach-state-park)
+- [Rockland Lake State Park](https://parks.ny.gov/visit/state-parks/rockland-lake-state-park)
+- [Memorial Park - Tripadvisor](https://www.tripadvisor.com/Attraction_Review-g48310-d12414869-Reviews-Memorial_Park-Nyack_New_York.html)
+- [Nyack Parks - Official Website](https://www.nyack.gov/maps/Parks)
+- [AllTrails - Hook Mountain](https://www.alltrails.com/trail/us/new-york/hook-mountain-nyack-beach-loop)
+- [AllTrails - Tallman Mountain](https://www.alltrails.com/parks/us/new-york/tallman-mountain-state-park)
+- [Nyack Library](https://www.nyacklibrary.org/)
+- [Edward Hopper House Museum](https://www.edwardhopperhouse.org/)
+- [K1 Speed West Nyack](https://www.k1speed.com/west-nyack-location.html)
+- [Palisades Center Ice Rink](https://palisadescentericerink.com/)
+- [AMC Palisades 21](https://www.amctheatres.com/movie-theatres/west-nyack/amc-palisades-21)
+- [Visit Nyack - Hudson River Boating](https://visitnyack.org/hudson-river-boating-nyack/)
+- [Rockland County YMCA](https://www.rocklandymca.org/main/nyack-health-fitness/)
+- [Historic Hudson River Towns - Piermont](https://www.hudsonriver.com/hhrt/find-your-path/piermont-piermont-pier/)
+- [Palisades Center Activities](https://palisadescenter.com/post/6-fun-safe-winter-break-activities-at-palisades-center/)
+- [Mommy Poppins - Palisades Center](https://mommypoppins.com/kids/the-palisades-center-mall-with-kids)

--- a/marketing-plan.md
+++ b/marketing-plan.md
@@ -1,0 +1,119 @@
+# Nyack Today Marketing Plan
+
+## Goal
+Achieve 100+ views/day through free channels and word-of-mouth.
+
+## Market Context
+
+**Combined Nyack Area Population:** ~12,100
+- Nyack: 7,400
+- Upper Nyack: 2,000
+- South Nyack: 2,700
+
+**Target Feasibility:** 100 views/day = 0.8% of local population daily, or ~25% monthly penetration. Very achievable given high median household income ($118k-$181k), cultural orientation, and Nyack's arts destination reputation.
+
+---
+
+## Phase 1: Local Partnerships (Week 1-2)
+
+### 1. Direct Outreach to Venues/Organizations
+- Email each venue: "We're featuring your events on Nyack Today for free"
+- Ask for website footer or events page link
+- Offer QR code posters they can print and display
+- **Target:** visitnyack.org, Levity Live, Tarrytown Music Hall, library, etc.
+
+### 2. Facebook Groups (Immediate)
+Join and become active in:
+- "Nyack Community Forum"
+- "Rockland County Events"
+- "Hudson Valley Things to Do"
+- Local parent groups
+
+**Strategy:**
+- Post weekly roundups ("This Weekend in Nyack"), not just links
+- Engage genuinely first, promote second
+
+### 3. Local Media/Bloggers
+- Pitch Nyack News & Views: "Local developer creates free events aggregator"
+- Reach out to Hudson Valley magazine, Rockland Daily blog
+- Offer to be their "events widget" for embedding
+
+---
+
+## Phase 2: Word of Mouth Engines (Week 2-4)
+
+### 4. QR Code Campaign
+- Design simple 4x6 cards: "What's happening in Nyack tonight?" + QR code
+- Ask friendly businesses to display: coffee shops, library, bookstores, gyms
+- Post on community boards at supermarkets
+
+### 5. Influencer Seeding
+- Identify 10-15 local "connectors" (PTA leaders, business owners, council members)
+- Personal email asking them to check it out and share if useful
+- Make it easy: "Just forward this to your network"
+
+### 6. Strategic Commenting
+- When someone asks "what's going on this weekend?" on Facebook/NextDoor, be helpful
+- Don't spam, just be the useful person who shares the link
+
+---
+
+## Phase 3: Content Strategy (Ongoing)
+
+### 7. Weekly Email Newsletter
+**"Nyack This Week"** - curated picks, not just a dump
+- Make it skimmable and personality-driven
+- Share-worthy subject lines: "5 things to do in Nyack this weekend under $20"
+
+### 8. Social Media Presence
+**Instagram:** @nyacktoday
+- Post daily at 4pm: "Tonight in Nyack: [3 events]"
+- Event photos (user-generated or venue photos)
+- Stories: polls ("Live music or comedy tonight?"), countdowns, behind-the-scenes
+
+### 9. SEO/Organic
+- Write simple blog posts: "Best family-friendly events in Nyack this month"
+- Optimize for "things to do in Nyack tonight/this weekend"
+- These rank for long-tail searches and drive steady traffic
+
+---
+
+## Quick Wins (Do First)
+
+1. **Google Business Profile** - Claim "Nyack Today" as a website/service
+2. **Signature lines** - Add link to your personal email signature
+3. **NextDoor post** - Introduction post in Nyack, Upper Nyack, South Nyack neighborhoods
+4. **Reddit** - r/hudsonvalley, r/rocklandcounty (be helpful, not spammy)
+5. **Email 5 friends** - Ask them to share with 3 people each
+
+---
+
+## Metrics to Track
+
+- Which channels drive traffic (add UTM parameters: `?utm_source=facebook`)
+- Peak usage times (to optimize social posting)
+- Which date filters people use most (tonight vs weekend)
+- Mobile vs desktop (should be 80%+ mobile for events)
+
+---
+
+## Expected Timeline
+
+- **Week 1-2**: 10-20 views/day (early adopters, friends, venues)
+- **Week 3-4**: 30-50 views/day (if QR codes deployed, social active)
+- **Month 2-3**: 75-100 views/day (if word-of-mouth kicks in)
+- **Month 4+**: 100-200 views/day (if you're consistent)
+
+---
+
+## Key Principle
+
+**Be useful, not promotional.** Position yourself as "the person who always knows what's happening" rather than "check out my website."
+
+---
+
+## Sources
+- [Nyack, New York Population 2025](https://worldpopulationreview.com/us-cities/new-york/nyack)
+- [Upper Nyack, New York Population 2026](https://worldpopulationreview.com/us-cities/new-york/upper-nyack)
+- [South Nyack, New York Demographics](https://www.city-data.com/city/South-Nyack-New-York.html)
+- [Nyack, NY | Data USA](https://datausa.io/profile/geo/nyack-ny)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Event {
   sourceName      String    // e.g., "Visit Nyack", "Levity Live"
   imageUrl        String?
   isHidden        Boolean   @default(false)
+  isMarquee       Boolean   @default(false)
   createdAt       DateTime  @default(now())
   updatedAt       DateTime  @updatedAt
 

--- a/public/favicon-v1.svg
+++ b/public/favicon-v1.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Cable-stayed bridge (Mario Cuomo / Tappan Zee) -->
+
+  <!-- Sky: warm sunset gradient via layers -->
+  <rect width="32" height="32" fill="#f97316" rx="4"/>
+  <rect x="0" y="0" width="32" height="32" fill="url(#sky)" rx="4"/>
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fb923c"/>
+      <stop offset="100%" stop-color="#fde68a"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Water -->
+  <rect x="0" y="22" width="32" height="10" rx="0" fill="#1d4ed8"/>
+  <!-- Water shimmer -->
+  <path d="M0 25 Q4 23.5 8 25 Q12 26.5 16 25 Q20 23.5 24 25 Q28 26.5 32 25" stroke="#60a5fa" stroke-width="1" fill="none" opacity="0.6"/>
+  <path d="M0 27.5 Q4 26 8 27.5 Q12 29 16 27.5 Q20 26 24 27.5 Q28 29 32 27.5" stroke="#93c5fd" stroke-width="0.7" fill="none" opacity="0.4"/>
+
+  <!-- Bridge deck -->
+  <rect x="1" y="20" width="30" height="2" fill="#fff" rx="0.5"/>
+
+  <!-- Left tower -->
+  <rect x="9.5" y="7" width="2" height="15" fill="#fff" rx="0.5"/>
+
+  <!-- Right tower -->
+  <rect x="20.5" y="7" width="2" height="15" fill="#fff" rx="0.5"/>
+
+  <!-- Left tower cables (fan) -->
+  <line x1="10.5" y1="7" x2="2" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="10.5" y1="7" x2="6"  y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="10.5" y1="7" x2="10" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="10.5" y1="7" x2="14" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+
+  <!-- Right tower cables (fan) -->
+  <line x1="21.5" y1="7" x2="18" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="21.5" y1="7" x2="22" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="21.5" y1="7" x2="26" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+  <line x1="21.5" y1="7" x2="30" y2="20" stroke="#fff" stroke-width="0.6" opacity="0.9"/>
+</svg>

--- a/public/favicon-v2.svg
+++ b/public/favicon-v2.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Hudson River sunset: landscape layers -->
+
+  <!-- Sky -->
+  <rect width="32" height="32" fill="#f97316" rx="4"/>
+
+  <!-- Horizon glow -->
+  <ellipse cx="16" cy="18" rx="14" ry="6" fill="#fbbf24" opacity="0.5"/>
+
+  <!-- Sun disk -->
+  <circle cx="16" cy="18" r="4.5" fill="#fef08a"/>
+
+  <!-- Hills / Palisades silhouette -->
+  <path d="M0 20 Q4 14 8 17 Q11 13 14 16 Q16 14 18 16 Q22 12 26 17 Q29 15 32 18 L32 20Z" fill="#92400e" opacity="0.85"/>
+
+  <!-- River -->
+  <rect x="0" y="20" width="32" height="12" fill="#1e40af" rx="0"/>
+
+  <!-- Sun reflection on water -->
+  <ellipse cx="16" cy="23" rx="4" ry="1.2" fill="#fde68a" opacity="0.5"/>
+
+  <!-- Water ripples -->
+  <path d="M6 25 Q10 23.5 14 25 Q18 26.5 22 25 Q26 23.5 30 25" stroke="#60a5fa" stroke-width="0.8" fill="none" opacity="0.5"/>
+  <path d="M4 28 Q9 26.5 14 28 Q19 29.5 24 28 Q28 26.5 31 28" stroke="#93c5fd" stroke-width="0.6" fill="none" opacity="0.35"/>
+</svg>

--- a/public/favicon-v3.svg
+++ b/public/favicon-v3.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- "N" monogram with Hudson River wave -->
+
+  <!-- Orange circle background -->
+  <circle cx="16" cy="16" r="15" fill="#f97316"/>
+
+  <!-- River wave band at bottom of circle -->
+  <clipPath id="clip">
+    <circle cx="16" cy="16" r="15"/>
+  </clipPath>
+  <rect x="0" y="22" width="32" height="10" fill="#1d4ed8" clip-path="url(#clip)"/>
+  <path d="M0 23 Q4 21 8 23 Q12 25 16 23 Q20 21 24 23 Q28 25 32 23" stroke="#60a5fa" stroke-width="1" fill="none" opacity="0.7" clip-path="url(#clip)"/>
+
+  <!-- Geometric "N" built from paths (no font dependency) -->
+  <!-- Left vertical stroke -->
+  <rect x="8" y="8" width="3" height="14" fill="#fff" rx="0.5"/>
+  <!-- Right vertical stroke -->
+  <rect x="21" y="8" width="3" height="14" fill="#fff" rx="0.5"/>
+  <!-- Diagonal stroke: top-left to bottom-right -->
+  <polygon points="11,8 14,8 22,22 19,22" fill="#fff"/>
+</svg>

--- a/public/favicon-v4.svg
+++ b/public/favicon-v4.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <!-- Sailboat on the Hudson -->
+
+  <!-- Sky background -->
+  <rect width="32" height="32" fill="#fed7aa" rx="4"/>
+
+  <!-- Sun -->
+  <circle cx="24" cy="9" r="4" fill="#f97316" opacity="0.9"/>
+
+  <!-- Light rays from sun -->
+  <line x1="24" y1="3" x2="24" y2="1" stroke="#fb923c" stroke-width="1" opacity="0.6"/>
+  <line x1="28.2" y1="4.8" x2="29.6" y2="3.4" stroke="#fb923c" stroke-width="1" opacity="0.6"/>
+  <line x1="30" y1="9" x2="32" y2="9" stroke="#fb923c" stroke-width="1" opacity="0.6"/>
+
+  <!-- Palisades / cliff silhouette far shore -->
+  <path d="M0 19 Q5 15 9 18 Q13 14 17 18 Q20 16 23 18 L32 18 L32 21 L0 21Z" fill="#92400e" opacity="0.4"/>
+
+  <!-- River -->
+  <rect x="0" y="20" width="32" height="12" fill="#1e40af" rx="0"/>
+
+  <!-- Water ripples -->
+  <path d="M2 23 Q7 21.5 12 23 Q17 24.5 22 23 Q27 21.5 31 23" stroke="#60a5fa" stroke-width="0.8" fill="none" opacity="0.55"/>
+  <path d="M2 26 Q7 24.5 12 26 Q17 27.5 22 26 Q27 24.5 31 26" stroke="#93c5fd" stroke-width="0.6" fill="none" opacity="0.4"/>
+
+  <!-- Boat hull -->
+  <path d="M10 20 Q16 22.5 22 20 L21 20 L11 20Z" fill="#7c2d12"/>
+  <path d="M11 20 L10 20 Q9.5 20.5 10.5 21 L21.5 21 Q22.5 20.5 22 20 Z" fill="#92400e"/>
+
+  <!-- Mast -->
+  <line x1="16" y1="9" x2="16" y2="20" stroke="#7c2d12" stroke-width="1.2"/>
+
+  <!-- Main sail -->
+  <polygon points="16,9 16,19 9,19" fill="#fff" opacity="0.95"/>
+
+  <!-- Jib sail -->
+  <polygon points="16,11 16,19 22,19" fill="#fef3c7" opacity="0.9"/>
+</svg>

--- a/public/favicon-v5.svg
+++ b/public/favicon-v5.svg
@@ -1,0 +1,131 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <!-- Sky: deep indigo at zenith → crimson → amber → golden yellow at horizon -->
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#1a0a2e"/>
+      <stop offset="20%"  stop-color="#6b1a1a"/>
+      <stop offset="50%"  stop-color="#c2410c"/>
+      <stop offset="78%"  stop-color="#f97316"/>
+      <stop offset="100%" stop-color="#fbbf24"/>
+    </linearGradient>
+
+    <!-- Atmospheric halo: wide radial glow at sun position -->
+    <radialGradient id="halo" cx="50%" cy="63%" r="55%">
+      <stop offset="0%"   stop-color="#fef3c7" stop-opacity="0.75"/>
+      <stop offset="35%"  stop-color="#fb923c" stop-opacity="0.35"/>
+      <stop offset="70%"  stop-color="#c2410c" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#c2410c" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- Water surface: dark navy sides → warm gold at center (sun column) -->
+    <linearGradient id="waterH" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%"   stop-color="#0a1628"/>
+      <stop offset="42%"  stop-color="#0f2744"/>
+      <stop offset="50%"  stop-color="#7c4a0a" stop-opacity="0.6"/>
+      <stop offset="58%"  stop-color="#0f2744"/>
+      <stop offset="100%" stop-color="#0a1628"/>
+    </linearGradient>
+
+    <!-- Water depth: lighter at surface, darker below -->
+    <linearGradient id="waterV" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#1e3a5f"/>
+      <stop offset="100%" stop-color="#060e1c"/>
+    </linearGradient>
+
+    <!-- Sun reflection column in water -->
+    <linearGradient id="sunCol" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%"   stop-color="#fde68a" stop-opacity="0.7"/>
+      <stop offset="60%"  stop-color="#f97316" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#f97316" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- Soft blur for sun halo and reflections -->
+    <filter id="glow" x="-80%" y="-80%" width="260%" height="260%">
+      <feGaussianBlur stdDeviation="1.8"/>
+    </filter>
+    <filter id="blur-xs" x="-30%" y="-10%" width="160%" height="120%">
+      <feGaussianBlur stdDeviation="0.45"/>
+    </filter>
+  </defs>
+
+  <!-- ── SKY ── -->
+  <rect width="32" height="32" fill="url(#sky)" rx="4"/>
+
+  <!-- Wide atmospheric halo around sun -->
+  <rect width="32" height="32" fill="url(#halo)" rx="4"/>
+
+  <!-- Cloud streaks (thin, backlit) -->
+  <path d="M1 7 Q7 6 13 7.5 Q19 8.5 26 7" stroke="#c2410c" stroke-width="0.55" fill="none" opacity="0.45"/>
+  <path d="M5 10.5 Q11 9.5 18 10.5 Q23 11 29 10" stroke="#ea580c" stroke-width="0.45" fill="none" opacity="0.35"/>
+  <path d="M2 13 Q9 12.5 15 13.5 Q21 14 28 13" stroke="#f97316" stroke-width="0.35" fill="none" opacity="0.25"/>
+
+  <!-- Sun: blurred halo then crisp disk -->
+  <circle cx="16" cy="20" r="5"   fill="#fef3c7" filter="url(#glow)" opacity="0.85"/>
+  <circle cx="16" cy="20" r="3"   fill="#fefce8"/>
+  <circle cx="16" cy="20" r="1.8" fill="#ffffff"/>
+
+  <!-- Thin horizon glow band (where sky meets water) -->
+  <rect x="0" y="19.5" width="32" height="1.5" fill="#fde68a" opacity="0.2"/>
+
+  <!-- ── WATER ── -->
+  <rect x="0" y="21" width="32" height="11" fill="url(#waterV)"/>
+  <rect x="0" y="21" width="32" height="11" fill="url(#waterH)" opacity="0.85"/>
+
+  <!-- Sun column reflection -->
+  <rect x="12.5" y="21" width="7" height="11" fill="url(#sunCol)"/>
+
+  <!-- Water ripple highlights (warm near center, cool at edges) -->
+  <path d="M11 22.5 Q13.5 21.5 16 22.5 Q18.5 23.5 21 22.5" stroke="#fde68a" stroke-width="0.5" fill="none" opacity="0.45"/>
+  <path d="M8 25 Q12 23.5 16 25 Q20 26.5 24 25"            stroke="#fbbf24" stroke-width="0.4" fill="none" opacity="0.25"/>
+  <path d="M4 27.5 Q9 26 16 27.5 Q23 29 28 27.5"           stroke="#3b82f6" stroke-width="0.4" fill="none" opacity="0.2"/>
+  <path d="M2 30 Q8 28.5 16 30 Q24 31.5 30 30"             stroke="#1d4ed8" stroke-width="0.35" fill="none" opacity="0.15"/>
+
+  <!-- ── BRIDGE ── -->
+
+  <!-- Bridge deck: dark base (shadow underside) then warm lit top surface -->
+  <rect x="1" y="19.2" width="30" height="2"   fill="#3d2008" rx="0.2" opacity="0.5"/>
+  <rect x="1" y="19.2" width="30" height="1.4" fill="#d4a96a" rx="0.2"/>
+  <line x1="1" y1="19.2" x2="31" y2="19.2" stroke="#fde68a" stroke-width="0.3" opacity="0.6"/>
+
+  <!-- LEFT TOWER — H-frame (two legs, crossbeam) -->
+  <!-- Shadow leg (right, facing away from sun) -->
+  <rect x="10.2" y="6.5" width="1.1" height="13" fill="#8a6840" rx="0.2"/>
+  <!-- Lit leg (left, sun-facing) -->
+  <rect x="8.8"  y="6.5" width="1.1" height="13" fill="#e8c98a" rx="0.2"/>
+  <!-- Lit edge gleam -->
+  <rect x="8.8"  y="6.5" width="0.3" height="13" fill="#fff5d6" rx="0.1" opacity="0.7"/>
+  <!-- Crossbeam -->
+  <rect x="8.8"  y="10.5" width="2.5" height="0.9" fill="#c4a462" rx="0.15"/>
+
+  <!-- RIGHT TOWER — H-frame -->
+  <rect x="20.7" y="6.5" width="1.1" height="13" fill="#e8c98a" rx="0.2"/>
+  <rect x="22.1" y="6.5" width="1.1" height="13" fill="#8a6840" rx="0.2"/>
+  <rect x="20.7" y="6.5" width="0.3" height="13" fill="#fff5d6" rx="0.1" opacity="0.7"/>
+  <rect x="20.7" y="10.5" width="2.5" height="0.9" fill="#c4a462" rx="0.15"/>
+
+  <!-- LEFT TOWER CABLES — fan pattern, warm golden tint -->
+  <line x1="9.4"  y1="7"  x2="2"   y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.8"/>
+  <line x1="9.4"  y1="7"  x2="5"   y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.85"/>
+  <line x1="9.4"  y1="7"  x2="8"   y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.9"/>
+  <line x1="9.4"  y1="7"  x2="12"  y2="19.2" stroke="#e8d5a0" stroke-width="0.45" opacity="0.8"/>
+  <line x1="9.4"  y1="7"  x2="15"  y2="19.2" stroke="#e8d5a0" stroke-width="0.4" opacity="0.65"/>
+
+  <!-- RIGHT TOWER CABLES -->
+  <line x1="21.6" y1="7"  x2="17"  y2="19.2" stroke="#e8d5a0" stroke-width="0.4" opacity="0.65"/>
+  <line x1="21.6" y1="7"  x2="20"  y2="19.2" stroke="#e8d5a0" stroke-width="0.45" opacity="0.8"/>
+  <line x1="21.6" y1="7"  x2="24"  y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.9"/>
+  <line x1="21.6" y1="7"  x2="27"  y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.85"/>
+  <line x1="21.6" y1="7"  x2="30"  y2="19.2" stroke="#e8c98a" stroke-width="0.5" opacity="0.8"/>
+
+  <!-- ── REFLECTIONS IN WATER ── (blurred, distorted) -->
+  <!-- Tower reflections -->
+  <rect x="8.8"  y="21.2" width="1.1" height="5.5" fill="#c4a462" rx="0.2" opacity="0.25" filter="url(#blur-xs)"/>
+  <rect x="10.2" y="21.2" width="1.1" height="5.5" fill="#5a4020" rx="0.2" opacity="0.15" filter="url(#blur-xs)"/>
+  <rect x="20.7" y="21.2" width="1.1" height="5.5" fill="#c4a462" rx="0.2" opacity="0.25" filter="url(#blur-xs)"/>
+  <rect x="22.1" y="21.2" width="1.1" height="5.5" fill="#5a4020" rx="0.2" opacity="0.15" filter="url(#blur-xs)"/>
+  <!-- Cable reflections (very faint, wavy) -->
+  <line x1="9.4" y1="21.2" x2="3"  y2="26" stroke="#c4a462" stroke-width="0.4" opacity="0.18" filter="url(#blur-xs)"/>
+  <line x1="9.4" y1="21.2" x2="7"  y2="26" stroke="#c4a462" stroke-width="0.4" opacity="0.18" filter="url(#blur-xs)"/>
+  <line x1="21.6" y1="21.2" x2="25" y2="26" stroke="#c4a462" stroke-width="0.4" opacity="0.18" filter="url(#blur-xs)"/>
+  <line x1="21.6" y1="21.2" x2="29" y2="26" stroke="#c4a462" stroke-width="0.4" opacity="0.18" filter="url(#blur-xs)"/>
+</svg>

--- a/src/app/admin/events/[id]/page.tsx
+++ b/src/app/admin/events/[id]/page.tsx
@@ -46,6 +46,7 @@ export default function EditEventPage() {
     sourceUrl: '',
     imageUrl: '',
     isHidden: false,
+    isMarquee: false,
   })
 
   const fetchEvent = async () => {
@@ -78,6 +79,7 @@ export default function EditEventPage() {
           sourceUrl: loaded.sourceUrl,
           imageUrl: loaded.imageUrl || '',
           isHidden: loaded.isHidden,
+          isMarquee: loaded.isMarquee,
         })
       } else {
         setError('Failed to load event')
@@ -396,6 +398,19 @@ export default function EditEventPage() {
           />
           <label htmlFor="isHidden" className="text-sm text-stone-700">
             Hide event from public view
+          </label>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="checkbox"
+            id="isMarquee"
+            checked={formData.isMarquee}
+            onChange={(e) => updateField('isMarquee', e.target.checked)}
+            className="rounded border-stone-300 text-orange-500 focus:ring-orange-500"
+          />
+          <label htmlFor="isMarquee" className="text-sm text-stone-700">
+            ⭐ Marquee event (high-draw, attracts visitors from outside Nyack)
           </label>
         </div>
 

--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -168,6 +168,11 @@ export default function AdminEventsPage() {
                             🔁
                           </span>
                         )}
+                        {event.isMarquee && (
+                          <span className="px-1.5 py-0.5 bg-amber-100 text-amber-700 text-xs rounded font-medium flex-shrink-0">
+                            ⭐
+                          </span>
+                        )}
                       </div>
                       <p className="text-sm text-stone-500">
                         {event.venue}, {event.city}

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -73,6 +73,7 @@ export async function PATCH(
     if (data.sourceUrl !== undefined) updateData.sourceUrl = data.sourceUrl
     if (data.imageUrl !== undefined) updateData.imageUrl = data.imageUrl
     if (data.isHidden !== undefined) updateData.isHidden = data.isHidden
+    if (data.isMarquee !== undefined) updateData.isMarquee = data.isMarquee
 
     const event = await prisma.event.update({
       where: { id },

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: NextRequest) {
     const familyFriendly = searchParams.get('familyFriendly') === 'true'
     const nyackOnly = searchParams.get('nyackOnly') === 'true'
     const nearbyOnly = searchParams.get('nearbyOnly') === 'true'
+    const marqueeOnly = searchParams.get('marquee') === 'true'
     const limit = parseInt(searchParams.get('limit') || '50', 10)
     const offset = parseInt(searchParams.get('offset') || '0', 10)
 
@@ -100,6 +101,11 @@ export async function GET(request: NextRequest) {
       where.isNyackProper = true
     } else if (nearbyOnly) {
       where.isNyackProper = false
+    }
+
+    // Marquee filter
+    if (marqueeOnly) {
+      where.isMarquee = true
     }
 
     // Get date range for recurring events query

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -226,7 +226,7 @@ export default function Home() {
       <Header />
       <Hero />
 
-      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-6 pb-12">
+      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-4 pb-12">
         <MarqueeSection onShowAll={handleShowAllMarquee} />
 
         <div className="mb-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -226,7 +226,7 @@ export default function Home() {
       <Header />
       <Hero />
 
-      <main id="events-section" className="max-w-4xl mx-auto px-4 py-12">
+      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-6 pb-12">
         <MarqueeSection onShowAll={handleShowAllMarquee} />
 
         <div className="mb-6">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import Header from '@/components/Header'
 import Hero from '@/components/Hero'
+import MarqueeSection from '@/components/MarqueeSection'
 import DateTabs from '@/components/DateTabs'
 import FilterBar, { Filters } from '@/components/FilterBar'
 import EventList from '@/components/EventList'
@@ -53,12 +54,19 @@ export default function Home() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showFallback, setShowFallback] = useState(false)
+  const [marqueeOnly, setMarqueeOnly] = useState(false)
 
   // Signals that the next 'week' fetch was triggered by tonight being empty
   const pendingFallbackRef = useRef(false)
 
   const buildQueryString = useCallback(() => {
     const params = new URLSearchParams()
+
+    if (marqueeOnly) {
+      params.set('marquee', 'true')
+      // No date param → API defaults to all future events
+      return params.toString()
+    }
 
     if (customDate) {
       params.set('date', 'custom')
@@ -83,7 +91,7 @@ export default function Home() {
     }
 
     return params.toString()
-  }, [dateFilter, filters, customDate])
+  }, [dateFilter, filters, customDate, marqueeOnly])
 
   const fetchEvents = useCallback(async () => {
     setLoading(true)
@@ -135,11 +143,25 @@ export default function Home() {
     fetchEvents()
   }, [fetchEvents])
 
+  const handleShowAllMarquee = useCallback(() => {
+    setMarqueeOnly(true)
+    pendingFallbackRef.current = false
+    setShowFallback(false)
+    setTimeout(() => {
+      document.getElementById('events-section')?.scrollIntoView({ behavior: 'smooth' })
+    }, 50)
+  }, [])
+
+  const handleClearMarquee = () => {
+    setMarqueeOnly(false)
+  }
+
   const handleDateFilterChange = (filter: DateFilter) => {
     pendingFallbackRef.current = false
     setShowFallback(false)
     setCustomDate(null)
     setDateFilter(filter)
+    setMarqueeOnly(false)
   }
 
   const handleCustomDateSelect = (date: Date) => {
@@ -161,6 +183,7 @@ export default function Home() {
   }
 
   const getHeading = () => {
+    if (marqueeOnly) return '⭐ Big Events'
     if (customDate) {
       return `Events on ${formatCustomDatePill(customDate)}`
     }
@@ -204,6 +227,8 @@ export default function Home() {
       <Hero />
 
       <main id="events-section" className="max-w-4xl mx-auto px-4 py-12">
+        <MarqueeSection onShowAll={handleShowAllMarquee} />
+
         <div className="mb-6">
           <h1 className="text-3xl font-bold text-stone-900 mb-2">
             {getHeading()}
@@ -226,6 +251,18 @@ export default function Home() {
         <div className="mb-6">
           <FilterBar filters={filters} onFiltersChange={setFilters} />
         </div>
+
+        {marqueeOnly && (
+          <div className="mb-4 bg-amber-50 border border-amber-200 rounded-xl px-4 py-2.5 flex items-center justify-between">
+            <span className="text-sm text-amber-800 font-medium">Showing all upcoming marquee events</span>
+            <button
+              onClick={handleClearMarquee}
+              className="text-amber-600 hover:text-amber-900 text-sm font-medium"
+            >
+              ✕ Clear
+            </button>
+          </div>
+        )}
 
         {showFallback && (
           <FallbackBanner onDismiss={handleFallbackDismiss} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -240,7 +240,7 @@ export default function Home() {
 
         <div className="mb-4">
           <DateTabs
-            activeFilter={dateFilter}
+            activeFilter={marqueeOnly ? 'custom' : dateFilter}
             onFilterChange={handleDateFilterChange}
             customDate={customDate}
             onCustomDateSelect={handleCustomDateSelect}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -226,7 +226,7 @@ export default function Home() {
       <Header />
       <Hero />
 
-      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-4 pb-12">
+      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-3 pb-12">
         <MarqueeSection onShowAll={handleShowAllMarquee} />
 
         <div className="mb-6">

--- a/src/components/DateTabs.tsx
+++ b/src/components/DateTabs.tsx
@@ -86,6 +86,7 @@ export default function DateTabs({
           <Drawer.Portal>
             <Drawer.Overlay className="fixed inset-0 bg-black/40 z-40" />
             <Drawer.Content className="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl z-50 outline-none">
+              <Drawer.Title className="sr-only">Pick a Date</Drawer.Title>
               <div className="pt-3 flex justify-center">
                 <div className="w-10 h-1 bg-stone-200 rounded-full" />
               </div>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -22,7 +22,11 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
       href={event.sourceUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="block bg-white rounded-xl border border-stone-200 p-4 hover:shadow-md hover:border-orange-200 transition-all"
+      className={`block rounded-xl border p-4 transition-all ${
+        event.isMarquee
+          ? 'bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400'
+          : 'bg-white border-stone-200 hover:shadow-md hover:border-orange-200'
+      }`}
     >
       <div className="flex gap-4">
         {/* Event image or category icon fallback */}
@@ -35,16 +39,23 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
             />
           </div>
         ) : (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg bg-orange-50 flex items-center justify-center text-3xl">
+          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center text-3xl ${event.isMarquee ? 'bg-amber-100' : 'bg-orange-50'}`}>
             {categoryIcon}
           </div>
         )}
 
         <div className="flex-1 min-w-0">
           {/* Title */}
-          <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
-            {title}
-          </h3>
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
+              {title}
+            </h3>
+            {event.isMarquee && (
+              <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-200 text-amber-800">
+                ⭐ Big Event
+              </span>
+            )}
+          </div>
 
           {/* Time and date */}
           <p className="text-sm text-stone-600 mt-1">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
 
       {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 pt-12 pb-8 max-w-6xl mx-auto w-full">
+      <div className="flex flex-col items-center justify-center px-4 pt-10 pb-4 max-w-6xl mx-auto w-full">
         {/* Hero headline */}
         <div className="text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
 
       {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 pt-10 pb-4 max-w-6xl mx-auto w-full">
+      <div className="flex flex-col items-center justify-center px-4 pt-8 pb-0 max-w-6xl mx-auto w-full">
         {/* Hero headline */}
         <div className="text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
 
       {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 pt-8 pb-0 max-w-6xl mx-auto w-full">
+      <div className="flex flex-col items-center justify-center px-4 pt-10 pb-4 max-w-6xl mx-auto w-full">
         {/* Hero headline */}
         <div className="text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -5,7 +5,7 @@ export default function Hero() {
       <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
 
       {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 py-16 max-w-6xl mx-auto w-full">
+      <div className="flex flex-col items-center justify-center px-4 pt-12 pb-8 max-w-6xl mx-auto w-full">
         {/* Hero headline */}
         <div className="text-center">
           <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">

--- a/src/components/MarqueeSection.tsx
+++ b/src/components/MarqueeSection.tsx
@@ -1,0 +1,154 @@
+'use client'
+
+import { useEffect, useState, useRef, useCallback } from 'react'
+import Link from 'next/link'
+import { Event } from '@prisma/client'
+import { formatTime, formatDate } from '@/lib/utils/dates'
+import { categoryIcons, categoryLabels, getCategoryColor } from '@/lib/utils/categories'
+import { decodeHtmlEntities } from '@/lib/utils/text'
+
+interface MarqueeSectionProps {
+  onShowAll: () => void
+}
+
+function convertDates(events: Event[]): Event[] {
+  return events.map((e) => ({
+    ...e,
+    startDate: new Date(e.startDate),
+    endDate: e.endDate ? new Date(e.endDate) : null,
+    createdAt: new Date(e.createdAt),
+    updatedAt: new Date(e.updatedAt),
+  }))
+}
+
+export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
+  const [events, setEvents] = useState<Event[]>([])
+  const [atStart, setAtStart] = useState(true)
+  const [atEnd, setAtEnd] = useState(false)
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    fetch('/api/events?marquee=true&limit=9')
+      .then((r) => r.json())
+      .then((data) => {
+        const evts = convertDates(data.events ?? [])
+        setEvents(evts)
+        setAtEnd(evts.length <= 3)
+      })
+      .catch(() => {})
+  }, [])
+
+  const updateArrows = useCallback(() => {
+    const el = scrollRef.current
+    if (!el) return
+    setAtStart(el.scrollLeft <= 4)
+    setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 4)
+  }, [])
+
+  const scrollLeft = () => {
+    scrollRef.current?.scrollBy({ left: -scrollRef.current.clientWidth, behavior: 'smooth' })
+  }
+
+  const scrollRight = () => {
+    scrollRef.current?.scrollBy({ left: scrollRef.current.clientWidth, behavior: 'smooth' })
+  }
+
+  if (events.length === 0) return null
+
+  return (
+    <div className="mb-8 bg-amber-50 border border-amber-200 rounded-2xl p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-amber-700 uppercase tracking-wide">
+          ⭐ Big Events
+        </h2>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onShowAll}
+            className="text-sm text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
+          >
+            See all →
+          </button>
+          {events.length > 3 && (
+            <div className="flex gap-1">
+              <button
+                onClick={scrollLeft}
+                disabled={atStart}
+                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+                aria-label="Previous"
+              >
+                ‹
+              </button>
+              <button
+                onClick={scrollRight}
+                disabled={atEnd}
+                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+                aria-label="Next"
+              >
+                ›
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div
+        ref={scrollRef}
+        onScroll={updateArrows}
+        className="flex gap-3 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+      >
+        {events.map((event) => {
+          const title = decodeHtmlEntities(event.title)
+          const icon = categoryIcons[event.category]
+          const label = categoryLabels[event.category]
+          const color = getCategoryColor(event.category)
+          const startDate = new Date(event.startDate)
+
+          return (
+            <Link
+              key={event.id}
+              href={event.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-shrink-0 w-[calc(33.333%-8px)] min-w-[200px] bg-white border border-amber-200 rounded-xl p-3 hover:shadow-md hover:border-amber-400 transition-all flex flex-col"
+            >
+              {event.imageUrl ? (
+                <div className="w-full aspect-video rounded-lg overflow-hidden bg-stone-100 mb-3">
+                  <img src={event.imageUrl} alt={title} className="w-full h-full object-cover" />
+                </div>
+              ) : (
+                <div className="w-full aspect-video rounded-lg bg-amber-50 flex items-center justify-center text-4xl mb-3">
+                  {icon}
+                </div>
+              )}
+
+              <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight text-sm flex-1">
+                {title}
+              </h3>
+              <p className="text-xs text-stone-500 mt-1">
+                {formatDate(startDate)} · {formatTime(startDate)}
+              </p>
+              <p className="text-xs text-stone-500 truncate mt-0.5">
+                {decodeHtmlEntities(event.venue)}
+              </p>
+              <div className="flex items-center gap-1.5 mt-2 flex-wrap">
+                <span className={`px-1.5 py-0.5 text-xs rounded-full font-medium ${color}`}>
+                  {label}
+                </span>
+                {event.isFree && (
+                  <span className="px-1.5 py-0.5 bg-green-100 text-green-700 text-xs rounded-full font-medium">
+                    Free
+                  </span>
+                )}
+                {event.isFamilyFriendly && (
+                  <span className="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full font-medium">
+                    Family
+                  </span>
+                )}
+              </div>
+            </Link>
+          )
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds an `isMarquee` boolean flag to the `Event` model for high-draw events (street fairs, fireworks, parades) that attract visitors from outside Nyack
- Surfaces marquee events in an amber-tinted carousel at the top of the main page — 3 cards wide, scrollable with prev/next arrows
- "See all →" link filters the main event list to marquee-only, with a banner and clear button to exit that mode
- Admin event edit page has a new ⭐ Marquee checkbox; events list shows an amber ⭐ badge on marquee events

## Test plan

- [x] Run `npx prisma generate` to pick up the new `isMarquee` field
- [x] Go to `/admin/events`, edit an upcoming event, check the ⭐ Marquee box, and save
- [x] Load the homepage — confirm the "⭐ Big Events" carousel appears above the date tabs
- [x] Confirm carousel arrows appear when there are >3 marquee events and navigate correctly
- [x] Click "See all →" — confirm it scrolls to the event list and shows only marquee events with the amber banner
- [x] Click "✕ Clear" or a date tab — confirm normal mode is restored
- [ ] Confirm the section is hidden when no marquee events exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)