### PR TITLE
fix: apply EXIF orientation for phone photo uploads

### DIFF
--- a/src/app/api/upload-image/route.ts
+++ b/src/app/api/upload-image/route.ts
@@ -71,7 +71,8 @@ export async function POST(request: NextRequest) {
       // Preserve GIFs as-is (don't resize animated GIFs)
       optimizedBuffer = buffer
     } else {
-      const sharpInstance = sharp(buffer)
+      // .rotate() auto-applies EXIF orientation so phone photos aren't sideways
+      const sharpInstance = sharp(buffer).rotate()
 
       if (shouldResize) {
         sharpInstance.resize(MAX_IMAGE_WIDTH, null, {


### PR DESCRIPTION
Fixes #57

Cell phone JPEGs store rotation in EXIF metadata rather than rotating actual pixels. When Sharp converted images to WebP, the EXIF data was stripped and photos appeared sideways.

Added `.rotate()` to the Sharp pipeline which auto-applies EXIF orientation before conversion.

Generated with [Claude Code](https://claude.ai/code)