### PR TITLE
feat: add email subscription and weekly digest

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -156,6 +156,19 @@ model EventSubmission {
   @@index([submittedAt])
 }
 
+// Email subscribers for the weekly digest
+model Subscriber {
+  id               String   @id @default(cuid())
+  email            String   @unique
+  isActive         Boolean  @default(true)
+  unsubscribeToken String   @unique @default(cuid())
+  subscribedAt     DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@index([isActive])
+  @@index([unsubscribeToken])
+}
+
 // Discord messages processed for event extraction
 model DiscordMessage {
   id              String   @id @default(cuid())

--- a/src/app/api/digest/route.ts
+++ b/src/app/api/digest/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { Resend } from 'resend'
+import { Event } from '@prisma/client'
+import { prisma } from '@/lib/db'
+import { generateDigestHtml, generateDigestText } from '@/lib/utils/email'
+
+async function generateWeeklySummary(events: Event[], weekLabel: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) return `${events.length} events happening in Nyack this week!`
+
+  try {
+    const OpenAI = (await import('openai')).default
+    const client = new OpenAI({ apiKey })
+
+    const eventList = events
+      .slice(0, 20)
+      .map(
+        (e) =>
+          `- ${e.title} at ${e.venue} on ${new Date(e.startDate).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: 'America/New_York' })}${e.isFree ? ' (Free)' : ''}`
+      )
+      .join('\n')
+
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      max_tokens: 300,
+      messages: [
+        {
+          role: 'user',
+          content: `Write a warm, fun 2-3 sentence intro for a weekly community events email for Nyack, NY for the week of ${weekLabel}. Highlight 1-2 specific exciting events. Keep it conversational and local. No generic phrases like "something for everyone."\n\nEvents this week:\n${eventList}`,
+        },
+      ],
+    })
+
+    return response.choices[0]?.message?.content ?? `${events.length} events happening in Nyack this week!`
+  } catch (error) {
+    console.error('OpenAI summary generation failed:', error)
+    return `${events.length} events happening in Nyack this week!`
+  }
+}
+
+function buildWeekLabel(start: Date, end: Date): string {
+  const fmt = (d: Date) =>
+    d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'America/New_York' })
+  return `${fmt(start)} – ${fmt(end)}`
+}
+
+export async function POST(request: NextRequest) {
+  const adminPassword = request.headers.get('x-admin-password')
+  const cronHeader = request.headers.get('authorization')
+
+  const hasValidAdmin = Boolean(
+    process.env.ADMIN_PASSWORD && adminPassword === process.env.ADMIN_PASSWORD
+  )
+  const hasValidCron =
+    Boolean(process.env.DIGEST_CRON_SECRET) &&
+    cronHeader === `Bearer ${process.env.DIGEST_CRON_SECRET}`
+
+  if (!hasValidAdmin && !hasValidCron) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: 'RESEND_API_KEY not configured' }, { status: 500 })
+  }
+
+  // Thursday send: cover Friday (tomorrow) through the following Thursday
+  const now = new Date()
+  const digestStart = new Date(now)
+  digestStart.setDate(now.getDate() + 1)
+  digestStart.setHours(0, 0, 0, 0)
+
+  const digestEnd = new Date(now)
+  digestEnd.setDate(now.getDate() + 7)
+  digestEnd.setHours(23, 59, 59, 999)
+
+  const weekLabel = buildWeekLabel(digestStart, digestEnd)
+
+  const [subscribers, events] = await Promise.all([
+    prisma.subscriber.findMany({ where: { isActive: true } }),
+    prisma.event.findMany({
+      where: {
+        isHidden: false,
+        startDate: { gte: digestStart, lte: digestEnd },
+      },
+      orderBy: { startDate: 'asc' },
+      take: 50,
+    }),
+  ])
+
+  if (subscribers.length === 0) {
+    return NextResponse.json({ message: 'No active subscribers', eventCount: events.length })
+  }
+
+  const aiSummary = await generateWeeklySummary(events, weekLabel)
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const resend = new Resend(apiKey)
+  const subject = `Nyack This Week — ${weekLabel}`
+
+  let sent = 0
+  for (const sub of subscribers) {
+    const unsubUrl = `${siteUrl}/api/unsubscribe?token=${sub.unsubscribeToken}`
+    try {
+      await resend.emails.send({
+        from: 'Nyack Today <submissions@nyacktoday.com>',
+        to: sub.email,
+        subject,
+        html: generateDigestHtml(events, aiSummary, unsubUrl, weekLabel),
+        text: generateDigestText(events, aiSummary, unsubUrl, weekLabel),
+      })
+      sent++
+    } catch (error) {
+      console.error(`Failed to send digest to ${sub.email}:`, error)
+    }
+  }
+
+  console.log(`Digest sent: ${sent}/${subscribers.length} subscribers, ${events.length} events, week: ${weekLabel}`)
+
+  return NextResponse.json({
+    subscriberCount: sent,
+    eventCount: events.length,
+    weekLabel,
+    aiSummary,
+  })
+}

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { sendWelcomeEmail } from '@/lib/utils/email'
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function POST(request: NextRequest) {
+  let body: { email?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 })
+  }
+
+  const email = (body.email ?? '').trim().toLowerCase()
+
+  if (!email || !EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: 'A valid email address is required' }, { status: 400 })
+  }
+
+  const subscriber = await prisma.subscriber.upsert({
+    where: { email },
+    update: { isActive: true },
+    create: { email },
+  })
+
+  await sendWelcomeEmail(subscriber.email, subscriber.unsubscribeToken)
+
+  return NextResponse.json({ message: 'Subscribed successfully' })
+}

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+export async function GET(request: NextRequest) {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const base = new URL('/unsubscribe', siteUrl)
+
+  const token = request.nextUrl.searchParams.get('token')
+
+  if (!token) {
+    base.searchParams.set('error', 'missing')
+    return NextResponse.redirect(base.toString())
+  }
+
+  const subscriber = await prisma.subscriber.findUnique({
+    where: { unsubscribeToken: token },
+  })
+
+  if (!subscriber) {
+    base.searchParams.set('error', 'invalid')
+    return NextResponse.redirect(base.toString())
+  }
+
+  if (!subscriber.isActive) {
+    base.searchParams.set('status', 'already')
+    return NextResponse.redirect(base.toString())
+  }
+
+  await prisma.subscriber.update({
+    where: { unsubscribeToken: token },
+    data: { isActive: false },
+  })
+
+  base.searchParams.set('status', 'success')
+  return NextResponse.redirect(base.toString())
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import EventList from '@/components/EventList'
 import { EventListSkeleton } from '@/components/EventCardSkeleton'
 import BottomNav from '@/components/BottomNav'
 import FallbackBanner from '@/components/FallbackBanner'
+import SubscribeSection from '@/components/SubscribeSection'
 import { DateFilter, formatCustomDatePill } from '@/lib/utils/dates'
 import { Event } from '@prisma/client'
 
@@ -291,6 +292,10 @@ export default function Home() {
             />
           )
         )}
+
+        <div id="subscribe-section" className="mt-10">
+          <SubscribeSection />
+        </div>
       </main>
 
       <BottomNav />

--- a/src/app/unsubscribe/UnsubscribeContent.tsx
+++ b/src/app/unsubscribe/UnsubscribeContent.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+
+export default function UnsubscribeContent() {
+  const searchParams = useSearchParams()
+  const status = searchParams.get('status')
+  const error = searchParams.get('error')
+
+  if (status === 'success') {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-stone-200 p-8 text-center">
+        <div className="w-12 h-12 rounded-full bg-stone-100 flex items-center justify-center mx-auto mb-4">
+          <svg className="w-6 h-6 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h1 className="text-2xl font-bold text-stone-900 mb-2">You&apos;ve been unsubscribed</h1>
+        <p className="text-stone-600 mb-6">You won&apos;t receive any more weekly digests from Nyack Today.</p>
+        <Link
+          href="/"
+          className="inline-block bg-orange-500 hover:bg-orange-600 text-white px-6 py-2.5 rounded-lg font-medium transition-colors"
+        >
+          Back to Events
+        </Link>
+      </div>
+    )
+  }
+
+  if (status === 'already') {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-stone-200 p-8 text-center">
+        <h1 className="text-2xl font-bold text-stone-900 mb-2">Already unsubscribed</h1>
+        <p className="text-stone-600 mb-6">This email is not currently subscribed to the Nyack Today digest.</p>
+        <Link href="/" className="text-orange-500 hover:text-orange-600 font-medium">
+          Back to Events
+        </Link>
+      </div>
+    )
+  }
+
+  if (error === 'invalid' || error === 'missing') {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-stone-200 p-8 text-center">
+        <h1 className="text-2xl font-bold text-stone-900 mb-2">Invalid link</h1>
+        <p className="text-stone-600 mb-6">
+          This unsubscribe link is invalid or has already been used. Use the link from your most recent digest email.
+        </p>
+        <Link href="/" className="text-orange-500 hover:text-orange-600 font-medium">
+          Back to Events
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-stone-200 p-8 text-center">
+      <h1 className="text-2xl font-bold text-stone-900 mb-2">Unsubscribe</h1>
+      <p className="text-stone-600 mb-6">
+        To unsubscribe, use the link at the bottom of your Nyack Today digest email.
+      </p>
+      <Link href="/" className="text-orange-500 hover:text-orange-600 font-medium">
+        Back to Events
+      </Link>
+    </div>
+  )
+}

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import Header from '@/components/Header'
+import BottomNav from '@/components/BottomNav'
+import UnsubscribeContent from './UnsubscribeContent'
+
+export const metadata = {
+  title: 'Unsubscribe — Nyack Today',
+}
+
+export default function UnsubscribePage() {
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <Header />
+      <main className="max-w-2xl mx-auto px-4 py-12">
+        <Suspense fallback={<div className="text-center text-stone-500">Loading...</div>}>
+          <UnsubscribeContent />
+        </Suspense>
+      </main>
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,12 +14,22 @@ export default function Header() {
     setMenuOpen(false)
 
     if (pathname === '/') {
-      // Already on homepage, scroll to events section
       const eventsSection = document.getElementById('events-section')
       eventsSection?.scrollIntoView({ behavior: 'smooth' })
     } else {
-      // On another page, navigate to homepage
       router.push('/')
+    }
+  }
+
+  const handleSubscribeClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    setMenuOpen(false)
+
+    if (pathname === '/') {
+      const subscribeSection = document.getElementById('subscribe-section')
+      subscribeSection?.scrollIntoView({ behavior: 'smooth' })
+    } else {
+      router.push('/#subscribe-section')
     }
   }
 
@@ -81,6 +91,12 @@ export default function Header() {
           >
             Submit Event
           </Link>
+          <button
+            onClick={handleSubscribeClick}
+            className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer"
+          >
+            Subscribe
+          </button>
         </nav>
       </div>
 
@@ -107,6 +123,12 @@ export default function Header() {
           >
             Submit Event
           </Link>
+          <button
+            onClick={handleSubscribeClick}
+            className="block w-full text-left px-4 py-3 text-orange-500 hover:bg-orange-50 font-medium"
+          >
+            Subscribe to Weekly Digest
+          </button>
         </nav>
       )}
     </header>

--- a/src/components/SubscribeSection.tsx
+++ b/src/components/SubscribeSection.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function SubscribeSection() {
+  const [email, setEmail] = useState('')
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle')
+  const [errorMessage, setErrorMessage] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setStatus('loading')
+    setErrorMessage('')
+
+    try {
+      const res = await fetch('/api/subscribe', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+
+      if (res.ok) {
+        setStatus('success')
+      } else {
+        const data = await res.json()
+        setStatus('error')
+        setErrorMessage(data.error ?? 'Something went wrong. Please try again.')
+      }
+    } catch {
+      setStatus('error')
+      setErrorMessage('Something went wrong. Please try again.')
+    }
+  }
+
+  return (
+    <div className="rounded-2xl bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 p-6">
+      <h2 className="text-xl font-bold text-stone-900 mb-1">Get Nyack in Your Inbox</h2>
+      <p className="text-stone-600 text-sm mb-4">
+        Every Thursday morning, a quick roundup of what&apos;s happening in Nyack this weekend and beyond — straight to your inbox.
+      </p>
+
+      <div aria-live="polite">
+        {status === 'success' ? (
+          <div className="flex items-center gap-2 text-green-700 font-medium">
+            <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+            You&apos;re subscribed! Check your inbox Thursday morning.
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+            <label htmlFor="subscribe-email" className="sr-only">Email address</label>
+            <input
+              id="subscribe-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              required
+              disabled={status === 'loading'}
+              className="flex-1 rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50"
+            />
+            <button
+              type="submit"
+              disabled={status === 'loading'}
+              className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 whitespace-nowrap"
+            >
+              {status === 'loading' ? 'Subscribing...' : 'Subscribe'}
+            </button>
+          </form>
+        )}
+
+        {status === 'error' && (
+          <p className="mt-2 text-sm text-red-600">{errorMessage}</p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -1117,6 +1117,195 @@ Reviewed: ${reviewedAt}
   `.trim()
 }
 
+// ─── Weekly Digest Emails ────────────────────────────────────────────────────
+
+function generateWelcomeHtmlEmail(unsubscribeUrl: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 0; }
+    .header { background-color: #f97316; color: white; padding: 30px 20px; text-align: center; }
+    .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
+    .content { padding: 24px 20px; }
+    .section { margin: 20px 0; padding: 15px; background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; }
+    .cta-button { display: inline-block; margin: 20px 0; padding: 12px 24px; background: #f97316; color: white !important; text-decoration: none; border-radius: 8px; font-weight: 600; }
+    .footer { margin-top: 30px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; }
+    a { color: #f97316; }
+  </style>
+</head>
+<body>
+  <div class="header"><h1>You're in! 🎉</h1></div>
+  <div class="content">
+    <p>Thanks for subscribing to the <strong>Nyack Today weekly digest</strong>.</p>
+    <div class="section">
+      Every <strong>Thursday morning</strong> you'll get a quick roundup of what's happening in Nyack and the surrounding area — this weekend and beyond.
+    </div>
+    <p>In the meantime, check out what's happening right now:</p>
+    <div style="text-align: center;">
+      <a href="${siteUrl}" class="cta-button">Browse Events</a>
+    </div>
+  </div>
+  <div class="footer">
+    <div>Nyack Today &middot; <a href="${siteUrl}">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
+    <div style="margin-top: 8px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
+  </div>
+</body>
+</html>`.trim()
+}
+
+function generateWelcomePlainTextEmail(unsubscribeUrl: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `
+YOU'RE SUBSCRIBED!
+==================
+
+Thanks for subscribing to the Nyack Today weekly digest.
+
+Every Thursday morning you'll get a quick roundup of what's happening in Nyack and the surrounding area — this weekend and beyond.
+
+Browse events now: ${siteUrl}
+
+---
+Unsubscribe: ${unsubscribeUrl}
+`.trim()
+}
+
+export async function sendWelcomeEmail(email: string, unsubscribeToken: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('Welcome email skipped: RESEND_API_KEY not configured')
+    return
+  }
+  try {
+    const resend = new Resend(apiKey)
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+    const unsubscribeUrl = `${siteUrl}/api/unsubscribe?token=${unsubscribeToken}`
+    await resend.emails.send({
+      from: 'Nyack Today <submissions@nyacktoday.com>',
+      to: email,
+      subject: "You're subscribed to the Nyack Today weekly digest!",
+      html: generateWelcomeHtmlEmail(unsubscribeUrl),
+      text: generateWelcomePlainTextEmail(unsubscribeUrl),
+    })
+    console.log(`Welcome email sent to: ${email}`)
+  } catch (error) {
+    console.error('Failed to send welcome email:', error)
+  }
+}
+
+export function generateDigestHtml(
+  events: Event[],
+  aiSummary: string,
+  unsubscribeUrl: string,
+  weekLabel: string
+): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
+  const formatEventDate = (date: Date) =>
+    new Date(date).toLocaleString('en-US', {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZone: 'America/New_York',
+    })
+
+  const eventRows = events.length === 0
+    ? `<p style="color: #57534e; font-style: italic;">No events found this week — check back next Thursday!</p>`
+    : events.map((e, i) => `
+      ${i > 0 ? '<hr style="border: none; border-top: 1px solid #e7e5e4; margin: 12px 0;">' : ''}
+      <div style="padding: 4px 0;">
+        <div style="margin-bottom: 4px;">
+          <a href="${escapeHtml(e.sourceUrl)}" style="color: #f97316; font-weight: 600; text-decoration: underline; font-size: 16px;">${escapeHtml(e.title)}</a>
+          ${e.isFree ? '<span style="margin-left: 8px; background: #dcfce7; color: #166534; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; display: inline-block;">FREE</span>' : ''}
+        </div>
+        <div style="color: #57534e; font-size: 14px;">${formatEventDate(e.startDate)}</div>
+        <div style="color: #78716c; font-size: 14px;">${escapeHtml(e.venue)}</div>
+      </div>`).join('')
+
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1c1917; max-width: 600px; margin: 0 auto; padding: 0; }
+    a { color: #f97316; }
+  </style>
+</head>
+<body>
+  <div style="background-color: #f97316; color: white; padding: 30px 20px; text-align: center;">
+    <div style="font-size: 13px; font-weight: 500; opacity: 0.85; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 1px;">Nyack Today</div>
+    <h1 style="margin: 0; font-size: 26px; font-weight: 700;">Nyack This Week</h1>
+    <div style="font-size: 15px; margin-top: 6px; opacity: 0.9;">${escapeHtml(weekLabel)}</div>
+  </div>
+
+  <div style="padding: 24px 20px;">
+    <div style="background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; padding: 16px; margin-bottom: 24px; color: #44403c; font-size: 15px; line-height: 1.7;">
+      ${escapeHtml(aiSummary)}
+    </div>
+
+    <h2 style="font-size: 18px; font-weight: 700; color: #1c1917; margin: 0 0 16px 0;">Upcoming Events</h2>
+    ${eventRows}
+
+    <div style="text-align: center; margin-top: 28px;">
+      <a href="${siteUrl}" style="display: inline-block; padding: 12px 28px; background: #f97316; color: white; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px;">See All Events</a>
+    </div>
+  </div>
+
+  <div style="margin-top: 20px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; text-align: center;">
+    <div><strong>Nyack Today</strong> &middot; <a href="${siteUrl}" style="color: #78716c;">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
+    <div style="margin-top: 6px;">You're receiving this because you subscribed at Nyack Today.</div>
+    <div style="margin-top: 6px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
+  </div>
+</body>
+</html>`.trim()
+}
+
+export function generateDigestText(
+  events: Event[],
+  aiSummary: string,
+  unsubscribeUrl: string,
+  weekLabel: string
+): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const formatEventDate = (date: Date) =>
+    new Date(date).toLocaleString('en-US', {
+      weekday: 'short', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York',
+    })
+
+  const eventLines = events.length === 0
+    ? 'No events found this week — check back next Thursday!'
+    : events.map(e =>
+        `${e.title}${e.isFree ? ' [FREE]' : ''}\n${formatEventDate(e.startDate)} · ${e.venue}\n${e.sourceUrl}`
+      ).join('\n\n')
+
+  return `
+NYACK THIS WEEK — ${weekLabel.toUpperCase()}
+${'='.repeat(40)}
+
+${aiSummary}
+
+UPCOMING EVENTS
+---------------
+${eventLines}
+
+See all events: ${siteUrl}
+
+---
+You're receiving this because you subscribed at Nyack Today.
+Unsubscribe: ${unsubscribeUrl}
+`.trim()
+}
+
 /**
  * Send rejection email to submitter when event is rejected
  * Includes optional reason from admin

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/scrape",
       "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/digest",
+      "schedule": "0 14 * * 4"
     }
   ],
   "functions": {


### PR DESCRIPTION
Users can subscribe via a form on the homepage or the nav Subscribe button. Every Thursday at 9 AM ET a digest covering Friday–Thursday is sent via Resend with an OpenAI-generated summary and event list. Token-based unsubscribe is handled via /api/unsubscribe.