### PR TITLE
feat: admin deduplication tool for merging duplicate events

### DIFF
--- a/src/app/admin/dedup/page.tsx
+++ b/src/app/admin/dedup/page.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useState } from 'react'
+
+interface EventSummary {
+  id: string
+  title: string
+  venue: string
+  startDate: string
+  sourceName: string
+  sourceUrl: string
+}
+
+interface GroupResult {
+  winner: EventSummary
+  losers: EventSummary[]
+  similarity: {
+    titleSimilarity: number
+    venueSimilarity: number
+  }
+}
+
+interface DedupResult {
+  dryRun: boolean
+  groupsFound: number
+  eventsDeleted: number
+  eventsUpdated: number
+  groups: GroupResult[]
+}
+
+function formatDate(dateStr: string) {
+  return new Date(dateStr).toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'America/New_York',
+  })
+}
+
+function EventCard({ event, label, color }: { event: EventSummary; label: string; color: 'green' | 'red' }) {
+  const borderClass = color === 'green' ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'
+  const badgeClass = color === 'green' ? 'text-green-700 bg-green-100' : 'text-red-700 bg-red-100'
+
+  return (
+    <div className={`border ${borderClass} rounded-lg p-4 mb-2`}>
+      <div className="flex items-center gap-2 mb-1">
+        <span className={`text-xs font-semibold ${badgeClass} px-2 py-0.5 rounded`}>
+          {label}
+        </span>
+        <a
+          href={event.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-medium text-stone-900 hover:text-orange-600 hover:underline"
+        >
+          {event.title}
+        </a>
+      </div>
+      <p className="text-sm text-stone-600">
+        {event.venue} &middot; {formatDate(event.startDate)}
+      </p>
+      <p className="text-xs text-stone-400 mt-1">Source: {event.sourceName}</p>
+    </div>
+  )
+}
+
+export default function AdminDedupPage() {
+  const [scanning, setScanning] = useState(false)
+  const [merging, setMerging] = useState(false)
+  const [result, setResult] = useState<DedupResult | null>(null)
+  const [mergeResult, setMergeResult] = useState<DedupResult | null>(null)
+  const [error, setError] = useState('')
+
+  const scan = async () => {
+    setScanning(true)
+    setError('')
+    setResult(null)
+    setMergeResult(null)
+    try {
+      const res = await fetch('/api/admin/dedup?dryRun=true', { method: 'POST' })
+      const data = await res.json()
+      if (!res.ok) { setError(data.error || 'Scan failed'); return }
+      setResult(data)
+    } catch {
+      setError('Scan failed')
+    } finally {
+      setScanning(false)
+    }
+  }
+
+  const mergeAll = async () => {
+    const loserCount = result!.groups.reduce((n, g) => n + g.losers.length, 0)
+    if (!confirm(`Merge ${result!.groupsFound} duplicate group(s) and delete ${loserCount} event(s)?`)) return
+    setMerging(true)
+    setError('')
+    try {
+      const res = await fetch('/api/admin/dedup?dryRun=false', { method: 'POST' })
+      const data = await res.json()
+      if (!res.ok) { setError(data.error || 'Merge failed'); return }
+      setMergeResult(data)
+      setResult(null)
+    } catch {
+      setError('Merge failed')
+    } finally {
+      setMerging(false)
+    }
+  }
+
+  const loserCount = result?.groups.reduce((n, g) => n + g.losers.length, 0) ?? 0
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-stone-900">Deduplication</h1>
+          <p className="text-sm text-stone-500">Scan upcoming events for duplicates and merge them</p>
+        </div>
+        <button
+          onClick={scan}
+          disabled={scanning || merging}
+          className="px-4 py-2 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 disabled:opacity-50 transition-colors"
+        >
+          {scanning ? 'Scanning...' : 'Scan for Duplicates'}
+        </button>
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-lg mb-6">
+          {error}
+        </div>
+      )}
+
+      {mergeResult && (
+        <div className="bg-green-50 border border-green-200 text-green-800 px-4 py-4 rounded-lg mb-6">
+          <p className="font-semibold">Merge complete</p>
+          <p className="text-sm">
+            {mergeResult.eventsDeleted} event{mergeResult.eventsDeleted !== 1 ? 's' : ''} deleted,{' '}
+            {mergeResult.eventsUpdated} winner{mergeResult.eventsUpdated !== 1 ? 's' : ''} updated with merged fields.
+          </p>
+          <button onClick={scan} className="mt-2 text-sm text-green-700 underline hover:text-green-900">
+            Scan again
+          </button>
+        </div>
+      )}
+
+      {result && (
+        <div>
+          <div className="flex items-center justify-between bg-white border border-stone-200 rounded-xl px-5 py-4 mb-6">
+            <div>
+              {result.groupsFound === 0 ? (
+                <p className="font-semibold text-green-700">No duplicates found</p>
+              ) : (
+                <>
+                  <p className="font-semibold text-stone-900">
+                    {result.groupsFound} duplicate group{result.groupsFound !== 1 ? 's' : ''} found
+                  </p>
+                  <p className="text-sm text-stone-500">
+                    {loserCount} event{loserCount !== 1 ? 's' : ''} will be removed
+                  </p>
+                </>
+              )}
+            </div>
+            {result.groupsFound > 0 && (
+              <button
+                onClick={mergeAll}
+                disabled={merging}
+                className="px-4 py-2 bg-red-500 text-white rounded-lg font-medium hover:bg-red-600 disabled:opacity-50 transition-colors"
+              >
+                {merging ? 'Merging...' : 'Merge All Duplicates'}
+              </button>
+            )}
+          </div>
+
+          {result.groups.map((group, i) => (
+            <div key={group.winner.id} className="bg-white border border-stone-200 rounded-xl p-5 mb-4">
+              <div className="flex items-center gap-2 mb-4">
+                <span className="text-xs font-medium bg-stone-100 text-stone-600 px-2 py-1 rounded">
+                  Group {i + 1}
+                </span>
+                <span className="text-xs text-stone-500">
+                  Title similarity: {(group.similarity.titleSimilarity * 100).toFixed(0)}%
+                  {' · '}
+                  Venue similarity: {(group.similarity.venueSimilarity * 100).toFixed(0)}%
+                </span>
+              </div>
+              <EventCard event={group.winner} label="KEEP" color="green" />
+              {group.losers.map(loser => (
+                <EventCard key={loser.id} event={loser} label="DELETE" color="red" />
+              ))}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!result && !mergeResult && !scanning && !error && (
+        <div className="text-center py-16 bg-white rounded-xl border border-stone-200">
+          <p className="text-stone-500 mb-2">Click Scan to check for duplicate events in the database</p>
+          <p className="text-sm text-stone-400">Only upcoming, visible, non-recurring events are checked</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -100,6 +100,7 @@ export default function AdminLayout({
     { href: '/admin/activities', label: 'Activities' },
     { href: '/admin/submissions', label: 'Submissions' },
     { href: '/admin/scrapers', label: 'Scrapers' },
+    { href: '/admin/dedup', label: 'Dedup' },
   ]
 
   return (

--- a/src/app/admin/scrapers/page.tsx
+++ b/src/app/admin/scrapers/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Fragment, useEffect, useState } from 'react'
 
 interface ScraperLog {
   id: string
@@ -200,9 +200,8 @@ export default function AdminScrapersPage() {
                 const clickable = log.eventsAdded > 0
 
                 return (
-                  <>
+                  <Fragment key={log.id}>
                     <tr
-                      key={log.id}
                       onClick={() => toggleAccordion(log)}
                       className={clickable ? 'cursor-pointer hover:bg-stone-50 transition-colors' : ''}
                     >
@@ -288,7 +287,7 @@ export default function AdminScrapersPage() {
                         </td>
                       </tr>
                     )}
-                  </>
+                  </Fragment>
                 )
               })}
             </tbody>

--- a/src/app/api/admin/dedup/route.ts
+++ b/src/app/api/admin/dedup/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+import { Event } from '@prisma/client'
+import { findDuplicateGroups, buildMergedEventData } from '@/lib/dedup'
+
+export async function POST(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    // Default to dryRun=true for safety — require explicit ?dryRun=false to mutate
+    const dryRun = searchParams.get('dryRun') !== 'false'
+
+    const now = new Date()
+    const events = await prisma.event.findMany({
+      where: {
+        startDate: { gte: now },
+        isHidden: false,
+        isRecurring: false,
+      },
+      orderBy: { startDate: 'asc' },
+    })
+
+    const groups = findDuplicateGroups(events)
+
+    let eventsDeleted = 0
+    let eventsUpdated = 0
+
+    if (!dryRun) {
+      for (const group of groups) {
+        await prisma.$transaction(async (tx) => {
+          // Accumulate merged updates across all losers cumulatively
+          const accumulatedUpdates: Partial<Event> = {}
+          for (const loser of group.losers) {
+            const loserUpdates = buildMergedEventData(
+              { ...group.winner, ...accumulatedUpdates } as Event,
+              loser
+            )
+            Object.assign(accumulatedUpdates, loserUpdates)
+          }
+
+          if (Object.keys(accumulatedUpdates).length > 0) {
+            await tx.event.update({
+              where: { id: group.winner.id },
+              data: accumulatedUpdates,
+            })
+            eventsUpdated++
+          }
+
+          for (const loser of group.losers) {
+            await tx.event.delete({ where: { id: loser.id } })
+            eventsDeleted++
+          }
+        })
+      }
+    }
+
+    return NextResponse.json({
+      dryRun,
+      groupsFound: groups.length,
+      eventsDeleted,
+      eventsUpdated,
+      groups: groups.map(group => ({
+        winner: {
+          id: group.winner.id,
+          title: group.winner.title,
+          venue: group.winner.venue,
+          startDate: group.winner.startDate,
+          sourceName: group.winner.sourceName,
+          sourceUrl: group.winner.sourceUrl,
+        },
+        losers: group.losers.map(l => ({
+          id: l.id,
+          title: l.title,
+          venue: l.venue,
+          startDate: l.startDate,
+          sourceName: l.sourceName,
+          sourceUrl: l.sourceUrl,
+        })),
+        similarity: group.similarity,
+      })),
+    })
+  } catch (error) {
+    console.error('Dedup API error:', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: 'Dedup scan failed', message }, { status: 500 })
+  }
+}

--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -1,0 +1,154 @@
+import { Event } from '@prisma/client'
+import { stringSimilarity, normalizeVenue, normalizeTitle } from './scrapers/utils'
+
+export interface DuplicateGroup {
+  winner: Event
+  losers: Event[]
+  similarity: {
+    titleSimilarity: number
+    venueSimilarity: number
+  }
+}
+
+export function scoreEventCompleteness(event: Event): number {
+  let score = 0
+  if (event.description && event.description.trim().length > 0) score++
+  if (event.endDate) score++
+  if (event.address && event.address.trim().length > 0) score++
+  if (event.price && event.price.trim().length > 0) score++
+  if (event.imageUrl && event.imageUrl.trim().length > 0) score++
+  if (event.category !== 'OTHER') score++
+  if (event.isMarquee) score += 2
+  return score
+}
+
+export function buildMergedEventData(winner: Event, loser: Event): Partial<Event> {
+  const updates: Partial<Event> = {}
+  if (!winner.description && loser.description) updates.description = loser.description
+  if (!winner.endDate && loser.endDate) updates.endDate = loser.endDate
+  if (!winner.address && loser.address) updates.address = loser.address
+  if (!winner.price && loser.price) updates.price = loser.price
+  if (!winner.imageUrl && loser.imageUrl) updates.imageUrl = loser.imageUrl
+  if (winner.category === 'OTHER' && loser.category !== 'OTHER') updates.category = loser.category
+  if (!winner.isFree && loser.isFree) updates.isFree = loser.isFree
+  if (!winner.isFamilyFriendly && loser.isFamilyFriendly) updates.isFamilyFriendly = loser.isFamilyFriendly
+  if (!winner.isMarquee && loser.isMarquee) updates.isMarquee = loser.isMarquee
+  return updates
+}
+
+function toLocalDateStr(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function findDuplicateGroups(events: Event[]): DuplicateGroup[] {
+  const VENUE_THRESHOLD = 0.7
+  const TITLE_THRESHOLD = 0.75
+
+  // Group by local date
+  const byDate = new Map<string, Event[]>()
+  for (const event of events) {
+    const key = toLocalDateStr(event.startDate)
+    const bucket = byDate.get(key) ?? []
+    bucket.push(event)
+    byDate.set(key, bucket)
+  }
+
+  // Union-find for transitive grouping
+  const parent = new Map<string, string>()
+  for (const event of events) {
+    parent.set(event.id, event.id)
+  }
+
+  function find(id: string): string {
+    if (parent.get(id) !== id) {
+      parent.set(id, find(parent.get(id)!))
+    }
+    return parent.get(id)!
+  }
+
+  function union(a: string, b: string) {
+    const ra = find(a)
+    const rb = find(b)
+    if (ra !== rb) parent.set(rb, ra)
+  }
+
+  // Within each day, group events by similar venue then check title similarity
+  for (const dayEvents of byDate.values()) {
+    // Build venue groups
+    const venueGroups: Event[][] = []
+    for (const event of dayEvents) {
+      const normVenue = normalizeVenue(event.venue)
+      let placed = false
+      for (const group of venueGroups) {
+        const repVenue = normalizeVenue(group[0].venue)
+        if (stringSimilarity(normVenue, repVenue) >= VENUE_THRESHOLD) {
+          group.push(event)
+          placed = true
+          break
+        }
+      }
+      if (!placed) venueGroups.push([event])
+    }
+
+    // Within each venue group, find duplicate title pairs
+    for (const group of venueGroups) {
+      if (group.length < 2) continue
+      for (let i = 0; i < group.length; i++) {
+        for (let j = i + 1; j < group.length; j++) {
+          const a = group[i]
+          const b = group[j]
+          const normA = normalizeTitle(a.title, a.venue)
+          const normB = normalizeTitle(b.title, b.venue)
+          const titleSim = stringSimilarity(normA, normB)
+          const isDuplicate =
+            titleSim >= TITLE_THRESHOLD ||
+            (normA.length > 0 && normB.length > 0 && (normA.includes(normB) || normB.includes(normA)))
+          if (isDuplicate) union(a.id, b.id)
+        }
+      }
+    }
+  }
+
+  // Collect union-find groups
+  const eventById = new Map(events.map(e => [e.id, e]))
+  const rootToMembers = new Map<string, string[]>()
+  for (const event of events) {
+    const root = find(event.id)
+    const members = rootToMembers.get(root) ?? []
+    members.push(event.id)
+    rootToMembers.set(root, members)
+  }
+
+  const groups: DuplicateGroup[] = []
+  for (const memberIds of rootToMembers.values()) {
+    if (memberIds.length < 2) continue
+    const members = memberIds.map(id => eventById.get(id)!).filter(Boolean)
+
+    // Pick winner: highest completeness, tie-break by earliest createdAt
+    const sorted = [...members].sort((a, b) => {
+      const scoreDiff = scoreEventCompleteness(b) - scoreEventCompleteness(a)
+      if (scoreDiff !== 0) return scoreDiff
+      return a.createdAt.getTime() - b.createdAt.getTime()
+    })
+
+    const winner = sorted[0]
+    const losers = sorted.slice(1)
+
+    // Best similarity score across pairs involving winner
+    let bestTitleSim = 0
+    let bestVenueSim = 0
+    for (const loser of losers) {
+      const ts = stringSimilarity(normalizeTitle(winner.title, winner.venue), normalizeTitle(loser.title, loser.venue))
+      const vs = stringSimilarity(normalizeVenue(winner.venue), normalizeVenue(loser.venue))
+      if (ts > bestTitleSim) bestTitleSim = ts
+      if (vs > bestVenueSim) bestVenueSim = vs
+    }
+
+    groups.push({ winner, losers, similarity: { titleSimilarity: bestTitleSim, venueSimilarity: bestVenueSim } })
+  }
+
+  return groups
+}

--- a/src/lib/scrapers/utils.ts
+++ b/src/lib/scrapers/utils.ts
@@ -53,7 +53,7 @@ export function stringSimilarity(a: string, b: string): number {
 /**
  * Normalize a title by removing common prefixes, venue names, and extra whitespace
  */
-function normalizeTitle(title: string, venue?: string): string {
+export function normalizeTitle(title: string, venue?: string): string {
   const prefixes = [
     'film screening:',
     'movie screening:',
@@ -123,7 +123,7 @@ function normalizeTitle(title: string, venue?: string): string {
 /**
  * Normalize a venue by extracting just the venue name (before address)
  */
-function normalizeVenue(venue: string): string {
+export function normalizeVenue(venue: string): string {
   let normalized = venue.toLowerCase().trim()
 
   // Extract venue name before comma (often followed by address)
@@ -174,9 +174,15 @@ export function areEventsDuplicates(
   date2: Date,
   similarityThreshold: number = 0.8
 ): boolean {
-  // Dates must match (same day)
-  const date1Str = date1.toISOString().split('T')[0]
-  const date2Str = date2.toISOString().split('T')[0]
+  // Dates must match (same day) — use local time methods to stay consistent with generateEventHash
+  const toLocalDateStr = (d: Date) => {
+    const y = d.getFullYear()
+    const m = String(d.getMonth() + 1).padStart(2, '0')
+    const day = String(d.getDate()).padStart(2, '0')
+    return `${y}-${m}-${day}`
+  }
+  const date1Str = toLocalDateStr(date1)
+  const date2Str = toLocalDateStr(date2)
   if (date1Str !== date2Str) {
     return false
   }


### PR DESCRIPTION
## Summary

- Adds `/admin/dedup` page where you can scan all upcoming events for duplicates, preview what would be merged, and execute the merge with one click
- New `POST /api/admin/dedup` endpoint supports `?dryRun=true` (preview only, the default) and `?dryRun=false` (actually merges winners and deletes losers in DB transactions)
- New `src/lib/dedup.ts` utility: `findDuplicateGroups()` groups events by same date + similar venue + similar title (≥0.75 Levenshtein similarity or substring match); `scoreEventCompleteness()` picks the winner; `buildMergedEventData()` patches the winner with any non-null fields from losers
- Fixes a timezone bug in `areEventsDuplicates()` — it was using `toISOString()` (UTC) for date comparison while `generateEventHash` uses local-time getters, causing mismatches on non-UTC machines
- Fixes a React `key` prop warning in the admin scrapers page (key was on inner `<tr>` instead of the outer fragment)

## Test plan

- [x] Navigate to `/admin/dedup` and click "Scan for Duplicates" — verify duplicate groups appear with KEEP/DELETE labels
- [x] Inspect a few groups to confirm the winner selection (more complete event kept) looks correct
- [x] Click "Merge All Duplicates", confirm the dialog, and verify the success banner shows correct counts
- [x] Re-scan — should show "No duplicates found"
- [x] Visit the main site and confirm previously duplicated events no longer appear twice
- [x] Verify `POST /api/admin/dedup` (no params) returns groups without mutating the DB
- [x] Verify `POST /api/admin/dedup?dryRun=false` actually deletes losers

🤖 Generated with [Claude Code](https://claude.ai/code)