### PR TITLE
fix: dedup not catching duplicates with parenthetical venue suffixes

### DIFF
--- a/src/lib/scrapers/utils.ts
+++ b/src/lib/scrapers/utils.ts
@@ -132,6 +132,9 @@ export function normalizeVenue(venue: string): string {
     normalized = normalized.substring(0, commaIndex).trim()
   }
 
+  // Remove trailing parenthetical qualifiers like "(outdoors)", "(outdoor stage)", "(bar)"
+  normalized = normalized.replace(/\s*\([^)]*\)\s*$/, '').trim()
+
   // Remove common words like "the" at the beginning
   if (normalized.startsWith('the ')) {
     normalized = normalized.substring(4)


### PR DESCRIPTION
Fixes #68

The `normalizeVenue` function was not stripping trailing parenthetical qualifiers like `(outdoors)` from venue names. This caused the Levenshtein similarity score between "Maureen's Jazz Cellar" and "Maureen's Jazz Cellar (outdoors)" to be ~0.65, below the 0.7 venue threshold, so the events were placed in separate venue groups and their titles were never compared.

The fix adds a single regex strip of trailing parentheticals in `normalizeVenue`.

Generated with [Claude Code](https://claude.ai/code)