### PR TITLE
feat: better image fallbacks and AI image generation for marquee events

### DIFF
--- a/src/app/admin/generate-images/page.tsx
+++ b/src/app/admin/generate-images/page.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+
+interface MarqueeEvent {
+  id: string
+  title: string
+  venue: string
+  category: string
+  startDate: string
+}
+
+interface GenerateResult {
+  id: string
+  title: string
+  imageUrl: string | null
+  error?: string
+}
+
+export default function GenerateImagesPage() {
+  const [events, setEvents] = useState<MarqueeEvent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [generating, setGenerating] = useState(false)
+  const [results, setResults] = useState<GenerateResult[]>([])
+  const [error, setError] = useState('')
+
+  const fetchEvents = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/admin/generate-event-images')
+      if (res.ok) {
+        const data = await res.json()
+        setEvents(data.events)
+      }
+    } catch {
+      setError('Failed to fetch events')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { fetchEvents() }, [])
+
+  const generate = async () => {
+    setGenerating(true)
+    setError('')
+    setResults([])
+    try {
+      const adminPassword = sessionStorage.getItem('admin_password') || ''
+      const res = await fetch('/api/admin/generate-event-images', {
+        method: 'POST',
+        headers: { 'x-admin-password': adminPassword },
+      })
+      if (!res.ok) {
+        const data = await res.json()
+        setError(data.error || 'Generation failed')
+        return
+      }
+      const data = await res.json()
+      setResults(data.generated)
+      await fetchEvents()
+    } catch {
+      setError('Failed to generate images')
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  const estimatedCost = (events.length * 0.04).toFixed(2)
+
+  return (
+    <div>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-stone-900">Generate Event Images</h1>
+        <p className="text-stone-500 mt-1">
+          Use DALL-E 3 to generate images for marquee events that don't have one yet. Images are persisted to Vercel Blob.
+        </p>
+      </div>
+
+      <div className="bg-white rounded-xl border border-stone-200 p-6 mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            {loading ? (
+              <p className="text-stone-500">Loading…</p>
+            ) : (
+              <>
+                <p className="font-medium text-stone-900">
+                  {events.length} marquee event{events.length !== 1 ? 's' : ''} without images
+                </p>
+                {events.length > 0 && (
+                  <p className="text-sm text-stone-400 mt-0.5">
+                    ~${estimatedCost} estimated cost (DALL-E 3 standard, $0.04/image)
+                  </p>
+                )}
+              </>
+            )}
+          </div>
+          <button
+            onClick={generate}
+            disabled={generating || loading || events.length === 0}
+            className="px-4 py-2 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            {generating ? 'Generating…' : 'Generate All'}
+          </button>
+        </div>
+
+        {generating && (
+          <p className="text-sm text-stone-500 italic">
+            This may take a minute — generating {events.length} image{events.length !== 1 ? 's' : ''} sequentially…
+          </p>
+        )}
+
+        {!generating && events.length > 0 && results.length === 0 && (
+          <ul className="divide-y divide-stone-100 mt-2">
+            {events.map((event) => (
+              <li key={event.id} className="py-2 text-sm text-stone-700">
+                <span className="font-medium">{event.title}</span>
+                <span className="text-stone-400 ml-2">· {event.venue}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {!loading && events.length === 0 && results.length === 0 && (
+          <p className="text-sm text-stone-500">All marquee events already have images.</p>
+        )}
+      </div>
+
+      {error && (
+        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-6 text-sm">
+          {error}
+        </div>
+      )}
+
+      {results.length > 0 && (
+        <div className="bg-white rounded-xl border border-stone-200 p-6">
+          <h2 className="font-semibold text-stone-900 mb-4">
+            Results — {results.filter((r) => r.imageUrl).length}/{results.length} generated successfully
+          </h2>
+          <div className="flex flex-col gap-4">
+            {results.map((result) => (
+              <div key={result.id} className="flex gap-4 items-start">
+                {result.imageUrl ? (
+                  <img
+                    src={result.imageUrl}
+                    alt={result.title}
+                    className="w-48 h-28 object-cover rounded-lg flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-48 h-28 bg-red-50 border border-red-100 rounded-lg flex items-center justify-center flex-shrink-0">
+                    <span className="text-xs text-red-400">Failed</span>
+                  </div>
+                )}
+                <div className="pt-1">
+                  <p className="font-medium text-stone-900 text-sm">{result.title}</p>
+                  {result.error && (
+                    <p className="text-xs text-red-500 mt-1">{result.error}</p>
+                  )}
+                  {result.imageUrl && (
+                    <a
+                      href={result.imageUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-orange-500 hover:underline mt-1 block"
+                    >
+                      View full image →
+                    </a>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/generate-images/page.tsx
+++ b/src/app/admin/generate-images/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { formatDate } from '@/lib/utils/dates'
 
 interface MarqueeEvent {
   id: string
@@ -8,170 +9,172 @@ interface MarqueeEvent {
   venue: string
   category: string
   startDate: string
+  imageUrl: string | null
+  suggestedPrompt: string
 }
 
-interface GenerateResult {
-  id: string
-  title: string
+interface EventState {
+  prompt: string
   imageUrl: string | null
-  error?: string
+  generating: boolean
+  error: string
 }
 
 export default function GenerateImagesPage() {
   const [events, setEvents] = useState<MarqueeEvent[]>([])
   const [loading, setLoading] = useState(true)
-  const [generating, setGenerating] = useState(false)
-  const [results, setResults] = useState<GenerateResult[]>([])
-  const [error, setError] = useState('')
+  const [states, setStates] = useState<Record<string, EventState>>({})
 
-  const fetchEvents = async () => {
-    setLoading(true)
-    try {
-      const res = await fetch('/api/admin/generate-event-images')
-      if (res.ok) {
-        const data = await res.json()
-        setEvents(data.events)
-      }
-    } catch {
-      setError('Failed to fetch events')
-    } finally {
-      setLoading(false)
-    }
-  }
+  useEffect(() => {
+    fetch('/api/admin/generate-event-images')
+      .then((r) => r.json())
+      .then((data) => {
+        setEvents(data.events ?? [])
+        const initial: Record<string, EventState> = {}
+        for (const e of data.events ?? []) {
+          initial[e.id] = {
+            prompt: e.suggestedPrompt,
+            imageUrl: e.imageUrl,
+            generating: false,
+            error: '',
+          }
+        }
+        setStates(initial)
+      })
+      .finally(() => setLoading(false))
+  }, [])
 
-  useEffect(() => { fetchEvents() }, [])
+  const update = (id: string, patch: Partial<EventState>) =>
+    setStates((prev) => ({ ...prev, [id]: { ...prev[id], ...patch } }))
 
-  const generate = async () => {
-    setGenerating(true)
-    setError('')
-    setResults([])
+  const generate = async (eventId: string) => {
+    const state = states[eventId]
+    if (!state || state.generating) return
+
+    update(eventId, { generating: true, error: '' })
+
     try {
       const adminPassword = sessionStorage.getItem('admin_password') || ''
       const res = await fetch('/api/admin/generate-event-images', {
         method: 'POST',
-        headers: { 'x-admin-password': adminPassword },
+        headers: {
+          'x-admin-password': adminPassword,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ eventId, prompt: state.prompt }),
       })
+      const data = await res.json()
       if (!res.ok) {
-        const data = await res.json()
-        setError(data.error || 'Generation failed')
+        update(eventId, { error: data.error || 'Generation failed', generating: false })
         return
       }
-      const data = await res.json()
-      setResults(data.generated)
-      await fetchEvents()
+      update(eventId, { imageUrl: data.imageUrl, generating: false })
     } catch {
-      setError('Failed to generate images')
-    } finally {
-      setGenerating(false)
+      update(eventId, { error: 'Failed to connect to server', generating: false })
     }
   }
 
-  const estimatedCost = (events.length * 0.04).toFixed(2)
+  if (loading) {
+    return (
+      <div>
+        <h1 className="text-2xl font-bold text-stone-900 mb-6">Generate Event Images</h1>
+        <p className="text-stone-500">Loading…</p>
+      </div>
+    )
+  }
 
   return (
     <div>
       <div className="mb-6">
         <h1 className="text-2xl font-bold text-stone-900">Generate Event Images</h1>
         <p className="text-stone-500 mt-1">
-          Use DALL-E 3 to generate images for marquee events that don't have one yet. Images are persisted to Vercel Blob.
+          Edit the prompt for each event, then generate. Images are saved immediately and will appear on the site.
         </p>
       </div>
 
-      <div className="bg-white rounded-xl border border-stone-200 p-6 mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            {loading ? (
-              <p className="text-stone-500">Loading…</p>
-            ) : (
-              <>
-                <p className="font-medium text-stone-900">
-                  {events.length} marquee event{events.length !== 1 ? 's' : ''} without images
+      <div className="flex flex-col gap-6">
+        {events.map((event) => {
+          const state = states[event.id]
+          if (!state) return null
+          const hasImage = !!state.imageUrl
+
+          return (
+            <div key={event.id} className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+              {/* Image strip */}
+              {state.imageUrl ? (
+                <img
+                  src={state.imageUrl}
+                  alt={event.title}
+                  className="w-full h-48 object-cover"
+                />
+              ) : (
+                <div className="w-full h-48 bg-stone-100 flex items-center justify-center">
+                  <span className="text-stone-400 text-sm">No image yet</span>
+                </div>
+              )}
+
+              <div className="p-5">
+                {/* Event info */}
+                <h2 className="font-semibold text-stone-900">{event.title}</h2>
+                <p className="text-sm text-stone-500 mt-0.5">
+                  {event.venue} · {formatDate(new Date(event.startDate))}
                 </p>
-                {events.length > 0 && (
-                  <p className="text-sm text-stone-400 mt-0.5">
-                    ~${estimatedCost} estimated cost (DALL-E 3 standard, $0.04/image)
-                  </p>
-                )}
-              </>
-            )}
-          </div>
-          <button
-            onClick={generate}
-            disabled={generating || loading || events.length === 0}
-            className="px-4 py-2 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            {generating ? 'Generating…' : 'Generate All'}
-          </button>
-        </div>
 
-        {generating && (
-          <p className="text-sm text-stone-500 italic">
-            This may take a minute — generating {events.length} image{events.length !== 1 ? 's' : ''} sequentially…
-          </p>
-        )}
+                {/* Prompt editor */}
+                <label className="block mt-4 mb-1 text-xs font-medium text-stone-500 uppercase tracking-wide">
+                  Prompt
+                </label>
+                <textarea
+                  value={state.prompt}
+                  onChange={(e) => update(event.id, { prompt: e.target.value })}
+                  rows={4}
+                  disabled={state.generating}
+                  className="w-full text-sm text-stone-800 border border-stone-200 rounded-lg p-3 resize-y focus:outline-none focus:ring-2 focus:ring-orange-400 disabled:opacity-50"
+                />
 
-        {!generating && events.length > 0 && results.length === 0 && (
-          <ul className="divide-y divide-stone-100 mt-2">
-            {events.map((event) => (
-              <li key={event.id} className="py-2 text-sm text-stone-700">
-                <span className="font-medium">{event.title}</span>
-                <span className="text-stone-400 ml-2">· {event.venue}</span>
-              </li>
-            ))}
-          </ul>
-        )}
+                {/* Actions */}
+                <div className="flex items-center gap-3 mt-3">
+                  <button
+                    onClick={() => generate(event.id)}
+                    disabled={state.generating || !state.prompt.trim()}
+                    className="px-4 py-2 bg-orange-500 text-white rounded-lg text-sm font-medium hover:bg-orange-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                  >
+                    {state.generating
+                      ? 'Generating…'
+                      : hasImage
+                      ? 'Regenerate'
+                      : 'Generate Image'}
+                  </button>
 
-        {!loading && events.length === 0 && results.length === 0 && (
-          <p className="text-sm text-stone-500">All marquee events already have images.</p>
-        )}
-      </div>
-
-      {error && (
-        <div className="bg-red-50 border border-red-200 text-red-700 rounded-lg p-4 mb-6 text-sm">
-          {error}
-        </div>
-      )}
-
-      {results.length > 0 && (
-        <div className="bg-white rounded-xl border border-stone-200 p-6">
-          <h2 className="font-semibold text-stone-900 mb-4">
-            Results — {results.filter((r) => r.imageUrl).length}/{results.length} generated successfully
-          </h2>
-          <div className="flex flex-col gap-4">
-            {results.map((result) => (
-              <div key={result.id} className="flex gap-4 items-start">
-                {result.imageUrl ? (
-                  <img
-                    src={result.imageUrl}
-                    alt={result.title}
-                    className="w-48 h-28 object-cover rounded-lg flex-shrink-0"
-                  />
-                ) : (
-                  <div className="w-48 h-28 bg-red-50 border border-red-100 rounded-lg flex items-center justify-center flex-shrink-0">
-                    <span className="text-xs text-red-400">Failed</span>
-                  </div>
-                )}
-                <div className="pt-1">
-                  <p className="font-medium text-stone-900 text-sm">{result.title}</p>
-                  {result.error && (
-                    <p className="text-xs text-red-500 mt-1">{result.error}</p>
+                  {!state.generating && state.prompt !== event.suggestedPrompt && (
+                    <button
+                      onClick={() => update(event.id, { prompt: event.suggestedPrompt })}
+                      className="text-sm text-stone-400 hover:text-stone-600 transition-colors"
+                    >
+                      Reset prompt
+                    </button>
                   )}
-                  {result.imageUrl && (
+
+                  {state.imageUrl && (
                     <a
-                      href={result.imageUrl}
+                      href={state.imageUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-xs text-orange-500 hover:underline mt-1 block"
+                      className="text-sm text-orange-500 hover:underline ml-auto"
                     >
-                      View full image →
+                      View full size →
                     </a>
                   )}
                 </div>
+
+                {state.error && (
+                  <p className="mt-2 text-sm text-red-500">{state.error}</p>
+                )}
               </div>
-            ))}
-          </div>
-        </div>
-      )}
+            </div>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -101,6 +101,7 @@ export default function AdminLayout({
     { href: '/admin/submissions', label: 'Submissions' },
     { href: '/admin/scrapers', label: 'Scrapers' },
     { href: '/admin/dedup', label: 'Dedup' },
+    { href: '/admin/generate-images', label: 'Generate Images' },
   ]
 
   return (

--- a/src/app/api/admin/generate-event-images/route.ts
+++ b/src/app/api/admin/generate-event-images/route.ts
@@ -20,9 +20,11 @@ function buildImagePrompt(
   )
 }
 
+const noImage = { OR: [{ imageUrl: null }, { imageUrl: '' }] }
+
 export async function GET() {
   const events = await prisma.event.findMany({
-    where: { isMarquee: true, imageUrl: null },
+    where: { isMarquee: true, ...noImage },
     select: { id: true, title: true, category: true, venue: true, startDate: true },
     orderBy: { startDate: 'asc' },
   })
@@ -41,7 +43,7 @@ export async function POST(request: NextRequest) {
   }
 
   const events = await prisma.event.findMany({
-    where: { isMarquee: true, imageUrl: null },
+    where: { isMarquee: true, ...noImage },
     select: { id: true, title: true, venue: true, description: true },
   })
 

--- a/src/app/api/admin/generate-event-images/route.ts
+++ b/src/app/api/admin/generate-event-images/route.ts
@@ -3,7 +3,7 @@ import OpenAI from 'openai'
 import { put } from '@vercel/blob'
 import { prisma } from '@/lib/db'
 
-function buildImagePrompt(
+export function buildImagePrompt(
   title: string,
   venue: string,
   description: string | null,
@@ -20,15 +20,28 @@ function buildImagePrompt(
   )
 }
 
-const noImage = { OR: [{ imageUrl: null }, { imageUrl: '' }] }
-
 export async function GET() {
   const events = await prisma.event.findMany({
-    where: { isMarquee: true, ...noImage },
-    select: { id: true, title: true, category: true, venue: true, startDate: true },
+    where: { isMarquee: true },
+    select: {
+      id: true,
+      title: true,
+      category: true,
+      venue: true,
+      startDate: true,
+      description: true,
+      imageUrl: true,
+    },
     orderBy: { startDate: 'asc' },
   })
-  return NextResponse.json({ events, count: events.length })
+
+  return NextResponse.json({
+    events: events.map((e) => ({
+      ...e,
+      imageUrl: e.imageUrl || null,
+      suggestedPrompt: buildImagePrompt(e.title, e.venue, e.description),
+    })),
+  })
 }
 
 export async function POST(request: NextRequest) {
@@ -42,60 +55,47 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 })
   }
 
-  const events = await prisma.event.findMany({
-    where: { isMarquee: true, ...noImage },
-    select: { id: true, title: true, venue: true, description: true },
-  })
+  const body = await request.json()
+  const { eventId, prompt } = body as { eventId?: string; prompt?: string }
 
-  if (events.length === 0) {
-    return NextResponse.json({ generated: [], count: 0 })
+  if (!eventId || !prompt?.trim()) {
+    return NextResponse.json({ error: 'eventId and prompt are required' }, { status: 400 })
   }
 
-  const client = new OpenAI({ apiKey })
-  const results: { id: string; title: string; imageUrl: string | null; error?: string }[] = []
+  try {
+    const client = new OpenAI({ apiKey })
 
-  for (const event of events) {
-    try {
-      const prompt = buildImagePrompt(event.title, event.venue, event.description)
+    const imageResponse = await client.images.generate({
+      model: 'dall-e-3',
+      prompt: prompt.trim(),
+      n: 1,
+      size: '1792x1024',
+      quality: 'standard',
+      style: 'natural',
+    })
 
-      const imageResponse = await client.images.generate({
-        model: 'dall-e-3',
-        prompt,
-        n: 1,
-        size: '1792x1024',
-        quality: 'standard',
-        style: 'natural',
-      })
+    const openAiUrl = imageResponse.data?.[0]?.url
+    if (!openAiUrl) throw new Error('No image URL returned from DALL-E 3')
 
-      const openAiUrl = imageResponse.data?.[0]?.url
-      if (!openAiUrl) throw new Error('No image URL returned from DALL-E 3')
+    // Download — OpenAI URLs expire after ~1 hour
+    const imgFetch = await fetch(openAiUrl)
+    if (!imgFetch.ok) throw new Error('Failed to download generated image')
+    const imgBuffer = Buffer.from(await imgFetch.arrayBuffer())
 
-      // Download the image — OpenAI URLs expire after ~1 hour
-      const imgFetch = await fetch(openAiUrl)
-      if (!imgFetch.ok) throw new Error('Failed to download generated image')
-      const imgBuffer = Buffer.from(await imgFetch.arrayBuffer())
+    const filename = `event-images/generated-${eventId}-${Date.now()}.png`
+    const blob = await put(filename, imgBuffer, {
+      access: 'public',
+      contentType: 'image/png',
+    })
 
-      // Upload to Vercel Blob for permanent storage
-      const filename = `event-images/generated-${event.id}-${Date.now()}.png`
-      const blob = await put(filename, imgBuffer, {
-        access: 'public',
-        contentType: 'image/png',
-      })
+    await prisma.event.update({
+      where: { id: eventId },
+      data: { imageUrl: blob.url },
+    })
 
-      await prisma.event.update({
-        where: { id: event.id },
-        data: { imageUrl: blob.url },
-      })
-
-      results.push({ id: event.id, title: event.title, imageUrl: blob.url })
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error'
-      results.push({ id: event.id, title: event.title, imageUrl: null, error: message })
-    }
+    return NextResponse.json({ imageUrl: blob.url })
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    return NextResponse.json({ error: message }, { status: 500 })
   }
-
-  return NextResponse.json({
-    generated: results,
-    count: results.filter((r) => r.imageUrl).length,
-  })
 }

--- a/src/app/api/admin/generate-event-images/route.ts
+++ b/src/app/api/admin/generate-event-images/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from 'next/server'
+import OpenAI from 'openai'
+import { put } from '@vercel/blob'
+import { prisma } from '@/lib/db'
+
+function buildImagePrompt(
+  title: string,
+  venue: string,
+  description: string | null,
+): string {
+  const eventDetail = description
+    ? `"${title}" at ${venue} — ${description.slice(0, 200)}`
+    : `"${title}" at ${venue}`
+
+  return (
+    `A photographic scene capturing the spirit of the event: ${eventDetail}. ` +
+    `Family friendly, street photography style, candid moment, natural light, ` +
+    `small Hudson Valley riverside town setting, authentic emotions. ` +
+    `No text, signs, or watermarks in the image.`
+  )
+}
+
+export async function GET() {
+  const events = await prisma.event.findMany({
+    where: { isMarquee: true, imageUrl: null },
+    select: { id: true, title: true, category: true, venue: true, startDate: true },
+    orderBy: { startDate: 'asc' },
+  })
+  return NextResponse.json({ events, count: events.length })
+}
+
+export async function POST(request: NextRequest) {
+  const adminPassword = request.headers.get('x-admin-password')
+  if (adminPassword !== process.env.ADMIN_PASSWORD) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) {
+    return NextResponse.json({ error: 'OPENAI_API_KEY not configured' }, { status: 500 })
+  }
+
+  const events = await prisma.event.findMany({
+    where: { isMarquee: true, imageUrl: null },
+    select: { id: true, title: true, venue: true, description: true },
+  })
+
+  if (events.length === 0) {
+    return NextResponse.json({ generated: [], count: 0 })
+  }
+
+  const client = new OpenAI({ apiKey })
+  const results: { id: string; title: string; imageUrl: string | null; error?: string }[] = []
+
+  for (const event of events) {
+    try {
+      const prompt = buildImagePrompt(event.title, event.venue, event.description)
+
+      const imageResponse = await client.images.generate({
+        model: 'dall-e-3',
+        prompt,
+        n: 1,
+        size: '1792x1024',
+        quality: 'standard',
+        style: 'natural',
+      })
+
+      const openAiUrl = imageResponse.data?.[0]?.url
+      if (!openAiUrl) throw new Error('No image URL returned from DALL-E 3')
+
+      // Download the image — OpenAI URLs expire after ~1 hour
+      const imgFetch = await fetch(openAiUrl)
+      if (!imgFetch.ok) throw new Error('Failed to download generated image')
+      const imgBuffer = Buffer.from(await imgFetch.arrayBuffer())
+
+      // Upload to Vercel Blob for permanent storage
+      const filename = `event-images/generated-${event.id}-${Date.now()}.png`
+      const blob = await put(filename, imgBuffer, {
+        access: 'public',
+        contentType: 'image/png',
+      })
+
+      await prisma.event.update({
+        where: { id: event.id },
+        data: { imageUrl: blob.url },
+      })
+
+      results.push({ id: event.id, title: event.title, imageUrl: blob.url })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error'
+      results.push({ id: event.id, title: event.title, imageUrl: null, error: message })
+    }
+  }
+
+  return NextResponse.json({
+    generated: results,
+    count: results.filter((r) => r.imageUrl).length,
+  })
+}

--- a/src/app/api/admin/generate-event-images/route.ts
+++ b/src/app/api/admin/generate-event-images/route.ts
@@ -8,16 +8,8 @@ export function buildImagePrompt(
   venue: string,
   description: string | null,
 ): string {
-  const eventDetail = description
-    ? `"${title}" at ${venue} — ${description.slice(0, 200)}`
-    : `"${title}" at ${venue}`
-
-  return (
-    `A photographic scene capturing the spirit of the event: ${eventDetail}. ` +
-    `Family friendly, street photography style, candid moment, natural light, ` +
-    `small Hudson Valley riverside town setting, authentic emotions. ` +
-    `No text, signs, or watermarks in the image.`
-  )
+  void description
+  return `${title} at ${venue}. in the style of a quick sketch. No text, signs, or watermarks in the image. Keep it abstract`
 }
 
 export async function GET() {

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -1,13 +1,31 @@
 import { Activity } from '@prisma/client'
-import { categoryIcons, categoryLabels, getCategoryColor } from '@/lib/utils/categories'
+import type { Category } from '@prisma/client'
+import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
 import Link from 'next/link'
+import {
+  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
+  Trophy, Building2, Palette, GraduationCap, Calendar,
+} from 'lucide-react'
+
+const categoryLucideIcons: Record<Category, React.ReactNode> = {
+  MUSIC:                <Music className="w-8 h-8 text-white" />,
+  COMEDY:               <Laugh className="w-8 h-8 text-white" />,
+  MOVIES:               <Film className="w-8 h-8 text-white" />,
+  THEATER:              <Mic2 className="w-8 h-8 text-white" />,
+  FAMILY_KIDS:          <Baby className="w-8 h-8 text-white" />,
+  FOOD_DRINK:           <UtensilsCrossed className="w-8 h-8 text-white" />,
+  SPORTS_RECREATION:    <Trophy className="w-8 h-8 text-white" />,
+  COMMUNITY_GOVERNMENT: <Building2 className="w-8 h-8 text-white" />,
+  ART_GALLERIES:        <Palette className="w-8 h-8 text-white" />,
+  CLASSES_WORKSHOPS:    <GraduationCap className="w-8 h-8 text-white" />,
+  OTHER:                <Calendar className="w-8 h-8 text-white" />,
+}
 
 interface ActivityCardProps {
   activity: Activity
 }
 
 export default function ActivityCard({ activity }: ActivityCardProps) {
-  const categoryIcon = categoryIcons[activity.category]
   const categoryLabel = categoryLabels[activity.category]
   const categoryColor = getCategoryColor(activity.category)
 
@@ -29,8 +47,8 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
             />
           </div>
         ) : (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg bg-orange-50 flex items-center justify-center text-3xl">
-            {categoryIcon}
+          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[activity.category]}`}>
+            {categoryLucideIcons[activity.category]}
           </div>
         )}
 

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,9 +1,28 @@
 import { Event } from '@prisma/client'
+import type { Category } from '@prisma/client'
 import { formatTime, formatDate } from '@/lib/utils/dates'
-import { categoryIcons, categoryLabels, getCategoryColor } from '@/lib/utils/categories'
+import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
 import { decodeHtmlEntities } from '@/lib/utils/text'
 import Link from 'next/link'
 import CalendarDropdown from './CalendarDropdown'
+import {
+  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
+  Trophy, Building2, Palette, GraduationCap, Calendar,
+} from 'lucide-react'
+
+const categoryLucideIcons: Record<Category, React.ReactNode> = {
+  MUSIC:                <Music className="w-8 h-8 text-white" />,
+  COMEDY:               <Laugh className="w-8 h-8 text-white" />,
+  MOVIES:               <Film className="w-8 h-8 text-white" />,
+  THEATER:              <Mic2 className="w-8 h-8 text-white" />,
+  FAMILY_KIDS:          <Baby className="w-8 h-8 text-white" />,
+  FOOD_DRINK:           <UtensilsCrossed className="w-8 h-8 text-white" />,
+  SPORTS_RECREATION:    <Trophy className="w-8 h-8 text-white" />,
+  COMMUNITY_GOVERNMENT: <Building2 className="w-8 h-8 text-white" />,
+  ART_GALLERIES:        <Palette className="w-8 h-8 text-white" />,
+  CLASSES_WORKSHOPS:    <GraduationCap className="w-8 h-8 text-white" />,
+  OTHER:                <Calendar className="w-8 h-8 text-white" />,
+}
 
 interface EventCardProps {
   event: Event
@@ -12,7 +31,6 @@ interface EventCardProps {
 
 export default function EventCard({ event, showDate = false }: EventCardProps) {
   const startDate = new Date(event.startDate)
-  const categoryIcon = categoryIcons[event.category]
   const categoryLabel = categoryLabels[event.category]
   const categoryColor = getCategoryColor(event.category)
   const title = decodeHtmlEntities(event.title)
@@ -39,8 +57,8 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
             />
           </div>
         ) : (
-          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center text-3xl ${event.isMarquee ? 'bg-amber-100' : 'bg-orange-50'}`}>
-            {categoryIcon}
+          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[event.category]}`}>
+            {categoryLucideIcons[event.category]}
           </div>
         )}
 

--- a/src/components/MarqueeSection.tsx
+++ b/src/components/MarqueeSection.tsx
@@ -3,9 +3,28 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
 import Link from 'next/link'
 import { Event } from '@prisma/client'
+import type { Category } from '@prisma/client'
 import { formatTime, formatDate } from '@/lib/utils/dates'
-import { categoryIcons, categoryLabels, getCategoryColor } from '@/lib/utils/categories'
+import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
 import { decodeHtmlEntities } from '@/lib/utils/text'
+import {
+  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
+  Trophy, Building2, Palette, GraduationCap, Calendar,
+} from 'lucide-react'
+
+const categoryLucideIcons: Record<Category, React.ReactNode> = {
+  MUSIC:                <Music className="w-10 h-10 text-white" />,
+  COMEDY:               <Laugh className="w-10 h-10 text-white" />,
+  MOVIES:               <Film className="w-10 h-10 text-white" />,
+  THEATER:              <Mic2 className="w-10 h-10 text-white" />,
+  FAMILY_KIDS:          <Baby className="w-10 h-10 text-white" />,
+  FOOD_DRINK:           <UtensilsCrossed className="w-10 h-10 text-white" />,
+  SPORTS_RECREATION:    <Trophy className="w-10 h-10 text-white" />,
+  COMMUNITY_GOVERNMENT: <Building2 className="w-10 h-10 text-white" />,
+  ART_GALLERIES:        <Palette className="w-10 h-10 text-white" />,
+  CLASSES_WORKSHOPS:    <GraduationCap className="w-10 h-10 text-white" />,
+  OTHER:                <Calendar className="w-10 h-10 text-white" />,
+}
 
 interface MarqueeSectionProps {
   onShowAll: () => void
@@ -98,7 +117,6 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
       >
         {events.map((event) => {
           const title = decodeHtmlEntities(event.title)
-          const icon = categoryIcons[event.category]
           const label = categoryLabels[event.category]
           const color = getCategoryColor(event.category)
           const startDate = new Date(event.startDate)
@@ -116,8 +134,8 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
                   <img src={event.imageUrl} alt={title} className="w-full h-full object-cover" />
                 </div>
               ) : (
-                <div className="w-full aspect-video rounded-lg bg-amber-50 flex items-center justify-center text-4xl mb-3">
-                  {icon}
+                <div className={`w-full aspect-video rounded-lg flex items-center justify-center mb-3 ${categoryGradients[event.category]}`}>
+                  {categoryLucideIcons[event.category]}
                 </div>
               )}
 

--- a/src/lib/utils/categories.ts
+++ b/src/lib/utils/categories.ts
@@ -59,6 +59,20 @@ export function guessCategory(title: string, description?: string | null): Categ
   return Category.OTHER
 }
 
+export const categoryGradients: Record<Category, string> = {
+  MUSIC:                'bg-gradient-to-br from-purple-500 to-indigo-600',
+  COMEDY:               'bg-gradient-to-br from-yellow-400 to-orange-500',
+  MOVIES:               'bg-gradient-to-br from-red-500 to-rose-600',
+  THEATER:              'bg-gradient-to-br from-pink-500 to-rose-500',
+  FAMILY_KIDS:          'bg-gradient-to-br from-green-400 to-emerald-500',
+  FOOD_DRINK:           'bg-gradient-to-br from-orange-400 to-amber-500',
+  SPORTS_RECREATION:    'bg-gradient-to-br from-blue-400 to-cyan-500',
+  COMMUNITY_GOVERNMENT: 'bg-gradient-to-br from-slate-400 to-gray-500',
+  ART_GALLERIES:        'bg-gradient-to-br from-indigo-400 to-violet-500',
+  CLASSES_WORKSHOPS:    'bg-gradient-to-br from-teal-400 to-cyan-500',
+  OTHER:                'bg-gradient-to-br from-stone-400 to-stone-500',
+}
+
 export function getCategoryColor(category: Category): string {
   const colors: Record<Category, string> = {
     MUSIC: 'bg-purple-100 text-purple-800',


### PR DESCRIPTION
## Summary

- Replaces generic emoji fallbacks on event and activity cards with category-specific gradient backgrounds + Lucide SVG icons (purple for Music, teal for Classes, pink for Theater, etc.)
- Applies the same gradient/icon treatment to the Big Events marquee section (wider `aspect-video` format)
- Adds a new **Generate Images** admin tool (`/admin/generate-images`) that uses DALL-E 3 to generate and persist images for marquee events
- Each event gets its own card with an editable prompt pre-filled from event title and venue, a Generate/Regenerate button, and an inline image preview — images are saved to Vercel Blob and persisted to the DB immediately
- Prompt style: quick sketch, abstract, no text/watermarks

## Test plan

- [x] Visit the home page and confirm event cards without images show colorful category gradients with white SVG icons instead of plain emoji boxes
- [x] Confirm the Big Events marquee section also shows gradients for events without images
- [x] Confirm events with real scraped images still display normally
- [x] Log in to `/admin/generate-images`, verify all 11 marquee events appear with editable prompts
- [x] Generate an image for one event, confirm it appears in the card and on the main site
- [x] Edit the prompt and regenerate — confirm the new image replaces the old one

🤖 Generated with [Claude Code](https://claude.com/claude-code)