### PR TITLE
feat: full visual redesign — forest green / terra palette

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -4,153 +4,181 @@ import { useState, useEffect } from 'react'
 import Header from '@/components/Header'
 import ActivityCard from '@/components/ActivityCard'
 import BottomNav from '@/components/BottomNav'
+import Footer from '@/components/Footer'
 import { Category } from '@prisma/client'
-import { categoryLabels } from '@/lib/utils/categories'
 import { Activity } from '@prisma/client'
 
-interface ActivityFilters {
-  category: Category | 'ALL'
-  priceFilter: 'all' | 'free' | 'paid'
-  familyFriendly: boolean
+const ACT_FILTERS = ['All', 'Outdoors', 'Family', 'Free', 'Food & Drink', 'Art']
+
+const chipBase: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  fontSize: 12,
+  padding: '7px 14px',
+  borderRadius: 20,
+  cursor: 'pointer',
+  border: '0.5px solid',
+  userSelect: 'none',
+  transition: 'all 0.15s',
+  fontWeight: 400,
+  whiteSpace: 'nowrap',
+  fontFamily: 'inherit',
+  background: 'transparent',
 }
 
 export default function ActivitiesPage() {
-  const [filters, setFilters] = useState<ActivityFilters>({
-    category: 'ALL',
-    priceFilter: 'all',
-    familyFriendly: false,
-  })
+  const [filter, setFilter] = useState('All')
   const [activities, setActivities] = useState<Activity[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    async function fetchActivities() {
-      setLoading(true)
-      try {
-        const response = await fetch('/api/activities')
-        if (response.ok) {
-          const data = await response.json()
-          setActivities(data.activities)
-        }
-      } catch (error) {
-        console.error('Failed to fetch activities:', error)
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchActivities()
+    fetch('/api/activities')
+      .then((r) => r.json())
+      .then((data) => setActivities(data.activities ?? []))
+      .catch(() => {})
+      .finally(() => setLoading(false))
   }, [])
 
-  // Filter activities based on current filters
-  const filteredActivities = activities.filter((activity) => {
-    // Category filter
-    if (filters.category !== 'ALL' && activity.category !== filters.category) {
-      return false
-    }
-
-    // Price filter
-    if (filters.priceFilter === 'free' && !activity.isFree) {
-      return false
-    }
-    if (filters.priceFilter === 'paid' && activity.isFree) {
-      return false
-    }
-
-    // Family-friendly filter
-    if (filters.familyFriendly && !activity.isFamilyFriendly) {
-      return false
-    }
-
+  const filtered = activities.filter((a) => {
+    if (filter === 'All') return true
+    if (filter === 'Free') return a.isFree
+    if (filter === 'Family') return a.isFamilyFriendly
+    if (filter === 'Outdoors') return a.category === 'SPORTS_RECREATION'
+    if (filter === 'Food & Drink') return a.category === 'FOOD_DRINK'
+    if (filter === 'Art') return a.category === 'ART_GALLERIES'
     return true
   })
 
-  const updateFilter = <K extends keyof ActivityFilters>(key: K, value: ActivityFilters[K]) => {
-    setFilters((prev) => ({ ...prev, [key]: value }))
-  }
-
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
 
-      <main className="max-w-4xl mx-auto px-4 py-6">
-        {/* Header section */}
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">
-            Always Available
+      {/* Hero */}
+      <section style={{ background: '#1E3A2F', padding: 'clamp(36px, 5vw, 56px) clamp(20px, 4vw, 48px)', position: 'relative', overflow: 'hidden' }}>
+        {/* Blob */}
+        <svg width="360" height="360" viewBox="0 0 360 360" style={{ position: 'absolute', right: -80, top: -60, pointerEvents: 'none', opacity: 1 }} aria-hidden="true">
+          <ellipse cx="180" cy="170" rx="150" ry="115" fill="#8FBD9E" opacity="0.18" transform="rotate(18 180 170)" />
+          <ellipse cx="225" cy="135" rx="80" ry="65" fill="#F5F0E8" opacity="0.12" />
+          <ellipse cx="120" cy="220" rx="50" ry="40" fill="#D4622A" opacity="0.18" />
+          <circle cx="265" cy="220" r="22" fill="#C8973A" opacity="0.25" />
+        </svg>
+
+        <div className="max-w-[1100px] mx-auto" style={{ position: 'relative' }}>
+          <span style={{
+            display: 'inline-block', background: '#C8973A', color: '#FEF0E6',
+            fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase',
+            padding: '5px 10px', borderRadius: 12, fontWeight: 500, marginBottom: 16,
+          }}>
+            Always on
+          </span>
+
+          <h1 style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'clamp(38px, 5vw, 56px)',
+            fontWeight: 600, color: '#F5F0E8', lineHeight: 1.05,
+            maxWidth: 600, letterSpacing: '-0.025em', marginBottom: 14,
+          }}>
+            Things you can do anytime.
           </h1>
-          <p className="text-stone-600">
-            Things to do anytime in Nyack and the surrounding area
+
+          <p style={{ fontSize: 16, color: '#8FBD9E', maxWidth: 520, lineHeight: 1.55, marginBottom: 28 }}>
+            Trails, parks, museums, and the slow pleasures of Main Street — the Nyack you can show up for any day of the week.
           </p>
-        </div>
 
-        {/* Filters */}
-        <div className="flex flex-wrap gap-2 items-center mb-6">
-          {/* Category filter */}
-          <select
-            value={filters.category}
-            onChange={(e) => updateFilter('category', e.target.value as Category | 'ALL')}
-            className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-          >
-            <option value="ALL">All Categories</option>
-            {Object.entries(categoryLabels).map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-          </select>
-
-          {/* Price filter */}
-          <select
-            value={filters.priceFilter}
-            onChange={(e) => updateFilter('priceFilter', e.target.value as ActivityFilters['priceFilter'])}
-            className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
-          >
-            <option value="all">Any Price</option>
-            <option value="free">Free Only</option>
-            <option value="paid">Paid Only</option>
-          </select>
-
-          {/* Family-friendly toggle */}
-          <button
-            onClick={() => updateFilter('familyFriendly', !filters.familyFriendly)}
-            className={`
-              px-3 py-2 rounded-lg text-sm font-medium transition-colors
-              ${
-                filters.familyFriendly
-                  ? 'bg-green-100 text-green-700 border border-green-300'
-                  : 'bg-white text-stone-600 border border-stone-200 hover:bg-stone-50'
-              }
-            `}
-          >
-            Family-Friendly
-          </button>
-        </div>
-
-        {/* Activities list */}
-        {loading ? (
-          <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mx-auto"></div>
+          <div className="flex flex-wrap gap-2">
+            {ACT_FILTERS.map((f) => {
+              const active = filter === f
+              return (
+                <button
+                  key={f}
+                  onClick={() => setFilter(f)}
+                  style={{
+                    ...chipBase,
+                    ...(active
+                      ? { background: '#D4622A', color: '#FEF0E6', borderColor: '#D4622A' }
+                      : { background: 'rgba(245,240,232,0.10)', color: '#C5DFC9', borderColor: 'rgba(245,240,232,0.20)' }
+                    ),
+                  }}
+                >
+                  {f}
+                </button>
+              )
+            })}
           </div>
-        ) : filteredActivities.length === 0 ? (
-          <div className="text-center py-12">
-            <div className="text-4xl mb-4">🎯</div>
-            <p className="text-stone-500">No activities found</p>
-            <p className="text-sm text-stone-400 mt-2">
-              {activities.length === 0
-                ? 'No activities have been added yet'
-                : 'Try adjusting your filters'}
+        </div>
+      </section>
+
+      <main style={{ background: '#F5F0E8' }}>
+        <div className="max-w-[1100px] mx-auto" style={{ padding: 'clamp(28px, 5vw, 48px) clamp(20px, 4vw, 48px) clamp(40px, 6vw, 56px)' }}>
+          {/* Section header */}
+          <div style={{ marginBottom: 20 }}>
+            <p style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: '#7A7468', marginBottom: 6, fontWeight: 500 }}>
+              The list
             </p>
+            <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 22, fontWeight: 600, color: '#1A1A14', letterSpacing: '-0.01em', lineHeight: 1.2, margin: 0 }}>
+              {filtered.length} {filtered.length === 1 ? 'way' : 'ways'} to spend a Nyack afternoon
+            </h2>
           </div>
-        ) : (
-          <div className="space-y-3">
-            {filteredActivities.map((activity) => (
-              <ActivityCard key={activity.id} activity={activity} />
-            ))}
+
+          {loading ? (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 16 }}>
+              {[1, 2, 3, 4].map((i) => (
+                <div key={i} className="animate-pulse" style={{ background: '#FDF8F0', border: '0.5px solid #DDD6C6', borderRadius: 16, height: 280 }} />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <div style={{ background: '#FDF8F0', border: '0.5px dashed #DDD6C6', borderRadius: 16, padding: 40, textAlign: 'center', color: '#7A7468', fontSize: 13 }}>
+              No activities match that filter.
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))', gap: 16 }}>
+              {filtered.map((activity) => (
+                <ActivityCard key={activity.id} activity={activity} />
+              ))}
+            </div>
+          )}
+
+          {/* Hike Nyack promo */}
+          <div style={{
+            marginTop: 'clamp(36px, 5vw, 56px)',
+            background: '#C8973A',
+            borderRadius: 18,
+            padding: 'clamp(24px, 4vw, 36px) clamp(22px, 4vw, 40px)',
+            display: 'flex',
+            flexDirection: 'row',
+            alignItems: 'center',
+            gap: 36,
+            flexWrap: 'wrap',
+          }}>
+            <div style={{ flex: 1, minWidth: 240 }}>
+              <p style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: '#5A4416', marginBottom: 8, fontWeight: 500 }}>
+                The map
+              </p>
+              <h3 style={{ fontFamily: 'var(--font-display)', fontSize: 'clamp(26px, 4vw, 34px)', fontWeight: 700, color: '#1E3A2F', letterSpacing: '-0.02em', lineHeight: 1.05, marginBottom: 10 }}>
+                Hike Nyack.
+              </h3>
+              <p style={{ fontSize: 14, color: '#3A2E12', maxWidth: 380, lineHeight: 1.55, marginBottom: 16 }}>
+                Hook Mountain, Nyack Beach, and the riverfront. Free at the visitor center.
+              </p>
+              <a
+                href="https://parks.ny.gov/parks/hookMountain"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{
+                  display: 'inline-block',
+                  background: '#1E3A2F', color: '#F5F0E8',
+                  fontSize: 13, padding: '11px 18px', borderRadius: 20,
+                  textDecoration: 'none', fontWeight: 500,
+                }}
+              >
+                Learn more →
+              </a>
+            </div>
           </div>
-        )}
+        </div>
       </main>
 
+      <Footer />
       <BottomNav />
     </div>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,75 +1,62 @@
 @import "tailwindcss";
 
 :root {
-  /* Sunset Orange Palette */
-  --primary-50: #fff7ed;
-  --primary-100: #ffedd5;
-  --primary-200: #fed7aa;
-  --primary-300: #fdba74;
-  --primary-400: #fb923c;
-  --primary-500: #f97316;
-  --primary-600: #ea580c;
-  --primary-700: #c2410c;
-  --primary-800: #9a3412;
-  --primary-900: #7c2d12;
-
-  /* Golden Hour */
-  --secondary-500: #eab308;
-
-  /* River Blue (accent) */
-  --accent-500: #0ea5e9;
-
-  /* Neutrals - warm stone */
-  --background: #fafaf9;
-  --foreground: #1c1917;
-  --muted: #78716c;
+  --color-forest:    #1E3A2F;
+  --color-terra:     #D4622A;
+  --color-oat:       #F5F0E8;
+  --color-surface:   #FDF8F0;
+  --color-deep:      #2C5240;
+  --color-amber:     #C8973A;
+  --color-slate:     #5B7FA6;
+  --color-text:      #1A1A14;
+  --color-muted:     #7A7468;
+  --color-border:    #DDD6C6;
+  --color-light-grn: #8FBD9E;
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-primary: var(--primary-500);
-  --color-primary-dark: var(--primary-600);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-background: var(--color-oat);
+  --color-foreground: var(--color-text);
+  --color-primary: var(--color-terra);
+  --font-sans: var(--font-sans);
+  --font-display: var(--font-display);
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+  background: #ECE4D2;
+  color: var(--color-text);
+  font-family: var(--font-sans), system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
-/* Custom utility classes */
-.text-primary {
-  color: var(--primary-500);
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: radial-gradient(rgba(122, 116, 104, 0.06) 1px, transparent 1px);
+  background-size: 4px 4px;
+  z-index: 0;
 }
 
-.bg-primary {
-  background-color: var(--primary-500);
+::selection {
+  background: var(--color-terra);
+  color: #FEF0E6;
 }
 
-.bg-primary-dark {
-  background-color: var(--primary-600);
-}
-
-.text-muted {
-  color: var(--muted);
-}
-
-/* react-day-picker custom theme */
 .rdp-custom {
-  --rdp-accent-color: #f97316;
-  --rdp-accent-background-color: #fff7ed;
-  --rdp-selected-border: 2px solid #f97316;
+  --rdp-accent-color: var(--color-terra);
+  --rdp-accent-background-color: #F5F0E8;
+  --rdp-selected-border: 2px solid var(--color-terra);
 }
 
 .rdp-custom .rdp-day_button:hover:not([disabled]) {
-  background-color: #fff7ed;
+  background-color: #F5F0E8;
 }
 
 .rdp-custom .rdp-selected .rdp-day_button {
-  background-color: #f97316;
+  background-color: var(--color-terra);
   color: white;
   font-weight: 600;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,20 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Fraunces } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plusJakarta = Plus_Jakarta_Sans({
+  variable: "--font-sans",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  display: "swap",
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const fraunces = Fraunces({
+  variable: "--font-display",
   subsets: ["latin"],
+  weight: ["500", "600", "700"],
+  display: "swap",
 });
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://nyacktoday.com';
@@ -69,7 +73,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  themeColor: "#f97316",
+  themeColor: "#1E3A2F",
 };
 
 export default function RootLayout({
@@ -79,10 +83,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-stone-50 min-h-screen`}
-      >
-        {children}
+      <body className={`${plusJakarta.variable} ${fraunces.variable} antialiased min-h-screen`}>
+        <div style={{ position: 'relative', zIndex: 1 }}>
+          {children}
+        </div>
         <Analytics />
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,24 +4,37 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import Header from '@/components/Header'
 import Hero from '@/components/Hero'
 import MarqueeSection from '@/components/MarqueeSection'
-import DateTabs from '@/components/DateTabs'
-import FilterBar, { Filters } from '@/components/FilterBar'
 import EventList from '@/components/EventList'
 import { EventListSkeleton } from '@/components/EventCardSkeleton'
 import BottomNav from '@/components/BottomNav'
-import FallbackBanner from '@/components/FallbackBanner'
+import Footer from '@/components/Footer'
 import SubscribeSection from '@/components/SubscribeSection'
-import { DateFilter, formatCustomDatePill } from '@/lib/utils/dates'
+import { DateFilter } from '@/lib/utils/dates'
 import { Event } from '@prisma/client'
+import { Category } from '@prisma/client'
+
+const QUICK_FILTER_MAP: Record<string, Partial<{ category: Category; free: boolean; familyFriendly: boolean }>> = {
+  Music:         { category: 'MUSIC' },
+  'Food & Drink':{ category: 'FOOD_DRINK' },
+  Family:        { familyFriendly: true },
+  Art:           { category: 'ART_GALLERIES' },
+  Community:     { category: 'COMMUNITY_GOVERNMENT' },
+  Free:          { free: true },
+  Outdoors:      { category: 'SPORTS_RECREATION' },
+}
+
+const DATE_TAB_LABELS: Record<DateFilter, string> = {
+  tonight: 'Today',
+  tomorrow: 'Tomorrow',
+  weekend: 'Weekend',
+  week: 'This Week',
+  month: 'This Month',
+  custom: 'Custom',
+}
 
 interface EventsApiResponse {
   events: Event[]
-  pagination: {
-    total: number
-    limit: number
-    offset: number
-    hasMore: boolean
-  }
+  pagination: { total: number; limit: number; offset: number; hasMore: boolean }
 }
 
 function convertEventDates(events: Event[]): Event[] {
@@ -35,39 +48,22 @@ function convertEventDates(events: Event[]): Event[] {
 }
 
 function isFallbackDismissed(): boolean {
-  try {
-    return sessionStorage.getItem('tonight-fallback-dismissed') === 'true'
-  } catch {
-    return false
-  }
+  try { return sessionStorage.getItem('tonight-fallback-dismissed') === 'true' } catch { return false }
 }
 
 export default function Home() {
   const [dateFilter, setDateFilter] = useState<DateFilter>('tonight')
   const [customDate, setCustomDate] = useState<Date | null>(null)
-  const [filters, setFilters] = useState<Filters>({
-    category: 'ALL',
-    priceFilter: 'all',
-    location: 'all',
-    familyFriendly: false,
-  })
+  const [quickFilter, setQuickFilter] = useState('All')
   const [events, setEvents] = useState<Event[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showFallback, setShowFallback] = useState(false)
-  const [marqueeOnly, setMarqueeOnly] = useState(false)
 
-  // Signals that the next 'week' fetch was triggered by tonight being empty
   const pendingFallbackRef = useRef(false)
 
   const buildQueryString = useCallback(() => {
     const params = new URLSearchParams()
-
-    if (marqueeOnly) {
-      params.set('marquee', 'true')
-      // No date param → API defaults to all future events
-      return params.toString()
-    }
 
     if (customDate) {
       params.set('date', 'custom')
@@ -76,23 +72,15 @@ export default function Home() {
       params.set('date', dateFilter)
     }
 
-    if (filters.category !== 'ALL') {
-      params.set('category', filters.category)
-    }
-    if (filters.priceFilter === 'free') {
-      params.set('free', 'true')
-    }
-    if (filters.location === 'nyack') {
-      params.set('nyackOnly', 'true')
-    } else if (filters.location === 'nearby') {
-      params.set('nearbyOnly', 'true')
-    }
-    if (filters.familyFriendly) {
-      params.set('familyFriendly', 'true')
+    const mapping = QUICK_FILTER_MAP[quickFilter]
+    if (mapping) {
+      if (mapping.category) params.set('category', mapping.category)
+      if (mapping.free) params.set('free', 'true')
+      if (mapping.familyFriendly) params.set('familyFriendly', 'true')
     }
 
     return params.toString()
-  }, [dateFilter, filters, customDate, marqueeOnly])
+  }, [dateFilter, quickFilter, customDate])
 
   const fetchEvents = useCallback(async () => {
     setLoading(true)
@@ -102,14 +90,11 @@ export default function Home() {
       const queryString = buildQueryString()
       const response = await fetch(`/api/events?${queryString}`)
 
-      if (!response.ok) {
-        throw new Error('Failed to fetch events')
-      }
+      if (!response.ok) throw new Error('Failed to fetch events')
 
       const data: EventsApiResponse = await response.json()
       const eventsWithDates = convertEventDates(data.events)
 
-      // Tonight is empty → switch to This Week tab and show fallback banner
       if (
         dateFilter === 'tonight' &&
         !customDate &&
@@ -118,10 +103,9 @@ export default function Home() {
       ) {
         pendingFallbackRef.current = true
         setDateFilter('week')
-        return // re-fetch will be triggered by dateFilter change
+        return
       }
 
-      // If this fetch was the result of a fallback from tonight, show the banner
       if (pendingFallbackRef.current && dateFilter === 'week') {
         pendingFallbackRef.current = false
         setShowFallback(true)
@@ -144,160 +128,117 @@ export default function Home() {
     fetchEvents()
   }, [fetchEvents])
 
-  const handleShowAllMarquee = useCallback(() => {
-    setMarqueeOnly(true)
-    pendingFallbackRef.current = false
-    setShowFallback(false)
-    setTimeout(() => {
-      document.getElementById('events-section')?.scrollIntoView({ behavior: 'smooth' })
-    }, 50)
-  }, [])
-
-  const handleClearMarquee = () => {
-    setMarqueeOnly(false)
-  }
-
   const handleDateFilterChange = (filter: DateFilter) => {
     pendingFallbackRef.current = false
     setShowFallback(false)
     setCustomDate(null)
     setDateFilter(filter)
-    setMarqueeOnly(false)
   }
 
-  const handleCustomDateSelect = (date: Date) => {
-    setCustomDate(date)
-  }
-
-  const handleCustomDateClear = () => {
-    setCustomDate(null)
-  }
-
-  const handleFallbackDismiss = () => {
-    try {
-      sessionStorage.setItem('tonight-fallback-dismissed', 'true')
-    } catch {
-      // sessionStorage unavailable
-    }
-    setShowFallback(false)
-    // Stay on This Week tab — events remain as-is
-  }
-
-  const getHeading = () => {
-    if (marqueeOnly) return '⭐ Big Events'
-    if (customDate) {
-      return `Events on ${formatCustomDatePill(customDate)}`
-    }
-    switch (dateFilter) {
-      case 'tonight':
-        return "What's Happening Today"
-      case 'tomorrow':
-        return "Tomorrow's Events"
-      case 'weekend':
-        return 'This Weekend'
-      case 'week':
-        return 'This Week'
-      case 'month':
-        return 'This Month'
-      default:
-        return 'Events'
-    }
-  }
+  const handleCustomDateSelect = (date: Date) => setCustomDate(date)
+  const handleCustomDateClear = () => setCustomDate(null)
 
   const getEmptyMessage = () => {
-    if (customDate) {
-      return `No events on ${formatCustomDatePill(customDate)}`
-    }
-    if (dateFilter === 'tonight') {
-      return 'No events tonight'
-    }
-    if (filters.familyFriendly) {
-      return 'No family-friendly events found for this time period'
-    }
-    if (filters.priceFilter === 'free') {
-      return 'No free events found for this time period'
-    }
-    return 'No events found for this time period'
+    const dateLabel = customDate ? 'that date' : DATE_TAB_LABELS[dateFilter]?.toLowerCase() || 'this period'
+    if (quickFilter !== 'All') return `No ${quickFilter.toLowerCase()} events for ${dateLabel}`
+    return `No events for ${dateLabel}`
   }
 
   const showDate = !!customDate || (dateFilter !== 'tonight' && dateFilter !== 'tomorrow')
 
+  const comingUpLabel =
+    quickFilter !== 'All'
+      ? `${events.length} ${events.length === 1 ? 'event' : 'events'} in ${quickFilter}`
+      : `${events.length} ${events.length === 1 ? 'event' : 'events'}`
+
+  const comingUpEyebrow = `Coming up · ${DATE_TAB_LABELS[dateFilter] || ''}`
+
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
-      <Hero />
 
-      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-3 pb-12">
-        <MarqueeSection onShowAll={handleShowAllMarquee} />
+      <Hero
+        dateFilter={dateFilter}
+        onDateFilterChange={handleDateFilterChange}
+        quickFilter={quickFilter}
+        onQuickFilterChange={setQuickFilter}
+        customDate={customDate}
+        onCustomDateSelect={handleCustomDateSelect}
+        onCustomDateClear={handleCustomDateClear}
+      />
 
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">
-            {getHeading()}
-          </h1>
-          <p className="text-stone-600">
-            Discover events and activities in Nyack and the surrounding area
-          </p>
-        </div>
+      <main id="events-section" style={{ background: '#F5F0E8' }}>
+        <div
+          className="max-w-[1100px] mx-auto"
+          style={{ padding: 'clamp(28px, 5vw, 48px) clamp(20px, 4vw, 48px) clamp(40px, 6vw, 56px)' }}
+        >
+          {/* Big events section */}
+          <MarqueeSection />
 
-        <div className="mb-4">
-          <DateTabs
-            activeFilter={marqueeOnly ? 'custom' : dateFilter}
-            onFilterChange={handleDateFilterChange}
-            customDate={customDate}
-            onCustomDateSelect={handleCustomDateSelect}
-            onCustomDateClear={handleCustomDateClear}
-          />
-        </div>
+          {/* Coming up section */}
+          <div style={{ marginBottom: 'clamp(36px, 5vw, 56px)' }}>
+            <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 16, gap: 16 }}>
+              <div>
+                <p style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: '#7A7468', marginBottom: 6, fontWeight: 500 }}>
+                  {comingUpEyebrow}
+                </p>
+                <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 22, fontWeight: 600, color: '#1A1A14', letterSpacing: '-0.01em', lineHeight: 1.2, margin: 0 }}>
+                  {comingUpLabel}
+                </h2>
+              </div>
+            </div>
 
-        <div className="mb-6">
-          <FilterBar filters={filters} onFiltersChange={setFilters} />
-        </div>
+            {showFallback && (
+              <div
+                style={{
+                  background: '#FDF8F0',
+                  border: '0.5px solid #DDD6C6',
+                  borderRadius: 12,
+                  padding: '10px 16px',
+                  marginBottom: 12,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 12,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <span style={{ fontSize: 13, color: '#7A7468' }}>Nothing on tonight — showing this week instead.</span>
+                <button
+                  onClick={() => {
+                    try { sessionStorage.setItem('tonight-fallback-dismissed', 'true') } catch {}
+                    setShowFallback(false)
+                  }}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#D4622A', fontSize: 12, fontWeight: 500, fontFamily: 'inherit' }}
+                >
+                  Dismiss
+                </button>
+              </div>
+            )}
 
-        {marqueeOnly && (
-          <div className="mb-4 bg-amber-50 border border-amber-200 rounded-xl px-4 py-2.5 flex items-center justify-between">
-            <span className="text-sm text-amber-800 font-medium">Showing all upcoming marquee events</span>
-            <button
-              onClick={handleClearMarquee}
-              className="text-amber-600 hover:text-amber-900 text-sm font-medium"
-            >
-              ✕ Clear
-            </button>
+            {error ? (
+              <div style={{ textAlign: 'center', padding: '32px 0' }}>
+                <p style={{ color: '#A24A3D', marginBottom: 12, fontSize: 13 }}>{error}</p>
+                <button
+                  onClick={fetchEvents}
+                  style={{ padding: '8px 16px', background: '#D4622A', color: '#FEF0E6', borderRadius: 20, border: 'none', cursor: 'pointer', fontSize: 13, fontFamily: 'inherit' }}
+                >
+                  Try Again
+                </button>
+              </div>
+            ) : loading ? (
+              <EventListSkeleton count={5} />
+            ) : (
+              <EventList events={events} showDate={showDate} emptyMessage={getEmptyMessage()} />
+            )}
           </div>
-        )}
 
-        {showFallback && (
-          <FallbackBanner onDismiss={handleFallbackDismiss} />
-        )}
-
-        {error && (
-          <div className="text-center py-8">
-            <p className="text-red-500 mb-4">{error}</p>
-            <button
-              onClick={fetchEvents}
-              className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
-            >
-              Try Again
-            </button>
-          </div>
-        )}
-
-        {!error && (
-          loading ? (
-            <EventListSkeleton count={5} />
-          ) : (
-            <EventList
-              events={events}
-              showDate={showDate}
-              emptyMessage={getEmptyMessage()}
-            />
-          )
-        )}
-
-        <div id="subscribe-section" className="mt-10">
+          {/* Subscribe */}
           <SubscribeSection />
         </div>
       </main>
 
+      <Footer />
       <BottomNav />
     </div>
   )

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -7,6 +7,7 @@ import { Category } from '@prisma/client'
 import { categoryLabels } from '@/lib/utils/categories'
 import Header from '@/components/Header'
 import BottomNav from '@/components/BottomNav'
+import Footer from '@/components/Footer'
 
 export default function SubmitEventPage() {
   const router = useRouter()
@@ -310,66 +311,69 @@ export default function SubmitEventPage() {
     }
   }
 
+  const resetForm = () => {
+    setSuccess(false)
+    setFormData({
+      title: '',
+      startDate: '',
+      startTime: '',
+      venue: '',
+      submitterEmail: '',
+      description: '',
+      endDate: '',
+      endTime: '',
+      address: '',
+      city: 'Nyack',
+      category: 'OTHER' as Category,
+      price: '',
+      isFree: false,
+      isFamilyFriendly: false,
+      sourceUrl: '',
+      imageUrl: '',
+      isRecurring: false,
+      recurrenceDays: [],
+      recurrenceEndDate: '',
+    })
+    setUploadMode('url')
+    setSelectedFile(null)
+    setPreviewUrl('')
+    setUploadError('')
+  }
+
   // Success state - show confirmation
   if (success) {
     return (
-      <div className="min-h-screen bg-stone-50">
+      <div className="min-h-screen">
         <Header />
-        <main className="max-w-2xl mx-auto px-4 py-12">
-          <div className="bg-white rounded-xl shadow-lg p-8 text-center">
-            <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-              </svg>
-            </div>
-            <h1 className="text-2xl font-bold text-stone-900 mb-2">Event Submitted!</h1>
-            <p className="text-stone-600 mb-6">
-              Thank you for submitting your event. Our team will review it and it should appear on the site within 24-48 hours.
-            </p>
-            <div className="flex gap-4 justify-center">
-              <Link
-                href="/"
-                className="px-6 py-2 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 transition-colors"
-              >
-                View Events
-              </Link>
-              <button
-                onClick={() => {
-                  setSuccess(false)
-                  setFormData({
-                    title: '',
-                    startDate: '',
-                    startTime: '',
-                    venue: '',
-                    submitterEmail: '',
-                    description: '',
-                    endDate: '',
-                    endTime: '',
-                    address: '',
-                    city: 'Nyack',
-                    category: 'OTHER' as Category,
-                    price: '',
-                    isFree: false,
-                    isFamilyFriendly: false,
-                    sourceUrl: '',
-                    imageUrl: '',
-                    isRecurring: false,
-                    recurrenceDays: [],
-                    recurrenceEndDate: '',
-                  })
-                  // Reset file upload state
-                  setUploadMode('url')
-                  setSelectedFile(null)
-                  setPreviewUrl('')
-                  setUploadError('')
-                }}
-                className="px-6 py-2 bg-stone-100 text-stone-700 rounded-lg font-medium hover:bg-stone-200 transition-colors"
-              >
-                Submit Another Event
-              </button>
+        <main style={{ background: '#F5F0E8', minHeight: '60vh' }}>
+          <div className="max-w-[720px] mx-auto" style={{ padding: 'clamp(28px, 5vw, 48px) clamp(20px, 4vw, 48px)' }}>
+            <div style={{ background: '#FDF8F0', border: '0.5px solid #DDD6C6', borderRadius: 18, padding: 'clamp(28px, 5vw, 48px)', textAlign: 'center' }}>
+              <div style={{ width: 56, height: 56, borderRadius: '50%', background: '#E8EFE0', color: '#1E3A2F', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 16 }}>
+                <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M5 12l5 5 9-11" />
+                </svg>
+              </div>
+              <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 26, fontWeight: 600, color: '#1A1A14', marginBottom: 8, margin: '0 0 8px' }}>
+                Thanks — we&rsquo;ve got it.
+              </h2>
+              <p style={{ fontSize: 14, color: '#7A7468', maxWidth: 360, margin: '0 auto 20px', lineHeight: 1.55 }}>
+                We&rsquo;ll review your submission and publish it within 24 hours.
+              </p>
+              <div className="flex gap-3 justify-center flex-wrap">
+                <Link href="/" style={{ display: 'inline-block', background: '#D4622A', color: '#FEF0E6', padding: '10px 20px', borderRadius: 20, fontSize: 13, fontWeight: 500, textDecoration: 'none' }}>
+                  View Events →
+                </Link>
+                <button
+                  onClick={resetForm}
+                  style={{ background: 'transparent', color: '#D4622A', border: '0.5px solid #D4622A', borderRadius: 20, padding: '10px 18px', fontSize: 13, cursor: 'pointer', fontWeight: 500, fontFamily: 'inherit' }}
+                >
+                  Submit another →
+                </button>
+              </div>
             </div>
           </div>
         </main>
+        <Footer />
         <BottomNav />
       </div>
     )
@@ -377,29 +381,42 @@ export default function SubmitEventPage() {
 
   // Form state - render form
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
 
-      <main className="max-w-2xl mx-auto px-4 py-8">
-        <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">Submit an Event</h1>
-          <p className="text-stone-600">
-            Know about an upcoming event in Nyack? Share it with the community!
-            We&apos;ll review your submission and add it to the calendar.
+      {/* Hero */}
+      <section style={{ background: '#1E3A2F', padding: 'clamp(36px, 5vw, 48px) clamp(20px, 4vw, 48px)', position: 'relative', overflow: 'hidden' }}>
+        <svg width="320" height="320" viewBox="0 0 360 360" style={{ position: 'absolute', right: -80, top: -40, pointerEvents: 'none', opacity: 1 }} aria-hidden="true">
+          <ellipse cx="180" cy="170" rx="150" ry="115" fill="#8FBD9E" opacity="0.18" transform="rotate(18 180 170)" />
+          <ellipse cx="120" cy="220" rx="50" ry="40" fill="#D4622A" opacity="0.18" />
+          <circle cx="265" cy="220" r="22" fill="#C8973A" opacity="0.25" />
+        </svg>
+        <div className="max-w-[720px] mx-auto" style={{ position: 'relative' }}>
+          <span style={{ display: 'inline-block', background: '#D4622A', color: '#FEF0E6', fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase', padding: '5px 10px', borderRadius: 12, fontWeight: 500, marginBottom: 16 }}>
+            For organizers
+          </span>
+          <h1 style={{ fontFamily: 'var(--font-display)', fontSize: 'clamp(34px, 5vw, 48px)', fontWeight: 600, color: '#F5F0E8', lineHeight: 1.1, maxWidth: 540, letterSpacing: '-0.025em', marginBottom: 12 }}>
+            Submit an event.
+          </h1>
+          <p style={{ fontSize: 15, color: '#8FBD9E', maxWidth: 520, lineHeight: 1.55 }}>
+            Got something happening in Nyack or the surrounding Hudson Valley? We review every submission and publish within 24 hours.
           </p>
         </div>
+      </section>
 
-        <form onSubmit={handleSubmit} className="bg-white rounded-xl shadow-lg p-6 space-y-6">
+      <main style={{ background: '#F5F0E8' }}>
+        <div className="max-w-[720px] mx-auto" style={{ padding: 'clamp(28px, 5vw, 48px) clamp(20px, 4vw, 48px) clamp(40px, 6vw, 64px)' }}>
+        <form onSubmit={handleSubmit} style={{ background: '#FDF8F0', border: '0.5px solid #DDD6C6', borderRadius: 18, padding: 'clamp(22px, 4vw, 36px)' }} className="space-y-6">
           {/* Poster Scan Section */}
-          <div className="bg-orange-50 border-2 border-orange-200 rounded-xl p-4">
+          <div className="bg-[#FDF8F0] border border-[#DDD6C6] rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
-              <svg className="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-[#D4622A]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              <h2 className="font-semibold text-orange-800">See a poster? Snap it to auto-fill!</h2>
+              <h2 className="font-semibold text-[#1E3A2F] font-semibold">See a poster? Snap it to auto-fill!</h2>
             </div>
-            <p className="text-sm text-orange-700 mb-3">
+            <p className="text-sm text-[#7A7468] mb-3">
               Take a photo of an event poster and we&apos;ll fill in the details for you automatically.
             </p>
 
@@ -422,7 +439,7 @@ export default function SubmitEventPage() {
               <button
                 type="button"
                 onClick={() => posterInputRef.current?.click()}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 active:bg-orange-700 transition-colors"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-[#D4622A] text-[#FEF0E6] rounded-2xl font-medium transition-colors"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
@@ -437,10 +454,10 @@ export default function SubmitEventPage() {
               <div className="space-y-3">
                 {posterPreview && (
                   <div className="relative">
-                    <img src={posterPreview} alt="Poster preview" className="w-full max-h-48 object-contain rounded-lg border border-orange-200" />
-                    <div className="absolute inset-0 bg-orange-900/40 rounded-lg flex items-center justify-center">
+                    <img src={posterPreview} alt="Poster preview" className="w-full max-h-48 object-contain rounded-lg border border-[#DDD6C6]" />
+                    <div className="absolute inset-0 bg-[#1E3A2F]/40 rounded-lg flex items-center justify-center">
                       <div className="bg-white rounded-lg px-4 py-2 flex items-center gap-2">
-                        <svg className="animate-spin h-4 w-4 text-orange-500" viewBox="0 0 24 24">
+                        <svg className="animate-spin h-4 w-4 text-[#D4622A]" viewBox="0 0 24 24">
                           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                         </svg>
@@ -455,7 +472,7 @@ export default function SubmitEventPage() {
             {/* Success state */}
             {posterFilled && posterPreview && !scanningPoster && (
               <div className="space-y-3">
-                <img src={posterPreview} alt="Scanned poster" className="w-full max-h-48 object-contain rounded-lg border border-orange-200" />
+                <img src={posterPreview} alt="Scanned poster" className="w-full max-h-48 object-contain rounded-lg border border-[#DDD6C6]" />
                 <div className="flex items-center gap-2 text-green-700 bg-green-50 rounded-lg px-3 py-2">
                   <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -471,7 +488,7 @@ export default function SubmitEventPage() {
                     setPreviewUrl('')
                     posterInputRef.current?.click()
                   }}
-                  className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                  className="text-sm text-[#D4622A] hover:text-[#7A7468] font-medium"
                 >
                   Scan a different poster
                 </button>
@@ -487,7 +504,7 @@ export default function SubmitEventPage() {
                 <button
                   type="button"
                   onClick={() => posterInputRef.current?.click()}
-                  className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                  className="text-sm text-[#D4622A] hover:text-[#7A7468] font-medium"
                 >
                   Try again
                 </button>
@@ -516,7 +533,7 @@ export default function SubmitEventPage() {
                 value={formData.title}
                 onChange={(e) => updateField('title', e.target.value)}
                 placeholder="e.g., Live Jazz at The Turning Point"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               />
             </div>
 
@@ -533,7 +550,7 @@ export default function SubmitEventPage() {
                     required
                     value={formData.startDate}
                     onChange={(e) => updateField('startDate', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                   />
                 </div>
               )}
@@ -546,7 +563,7 @@ export default function SubmitEventPage() {
                   required
                   value={formData.startTime}
                   onChange={(e) => updateField('startTime', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                 />
               </div>
             </div>
@@ -624,7 +641,7 @@ export default function SubmitEventPage() {
                       type="date"
                       value={formData.recurrenceEndDate}
                       onChange={(e) => updateField('recurrenceEndDate', e.target.value)}
-                      className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+                      className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-purple-500"
                     />
                     <p className="text-xs text-stone-500 mt-1">
                       Leave blank if this event continues indefinitely
@@ -645,7 +662,7 @@ export default function SubmitEventPage() {
                 value={formData.venue}
                 onChange={(e) => updateField('venue', e.target.value)}
                 placeholder="e.g., The Turning Point"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               />
             </div>
 
@@ -660,7 +677,7 @@ export default function SubmitEventPage() {
                 value={formData.submitterEmail}
                 onChange={(e) => updateField('submitterEmail', e.target.value)}
                 placeholder="your@email.com"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               />
               <p className="text-xs text-stone-500 mt-1">
                 We&apos;ll only use this to contact you about your submission if needed
@@ -682,7 +699,7 @@ export default function SubmitEventPage() {
                 value={formData.description}
                 onChange={(e) => updateField('description', e.target.value)}
                 placeholder="Tell us more about this event..."
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               />
             </div>
 
@@ -697,7 +714,7 @@ export default function SubmitEventPage() {
                     type="date"
                     value={formData.endDate}
                     onChange={(e) => updateField('endDate', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                   />
                 </div>
                 <div>
@@ -708,7 +725,7 @@ export default function SubmitEventPage() {
                     type="time"
                     value={formData.endTime}
                     onChange={(e) => updateField('endTime', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                   />
                 </div>
               </div>
@@ -725,7 +742,7 @@ export default function SubmitEventPage() {
                   value={formData.address}
                   onChange={(e) => updateField('address', e.target.value)}
                   placeholder="123 Main Street"
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                 />
               </div>
               <div>
@@ -736,7 +753,7 @@ export default function SubmitEventPage() {
                   type="text"
                   value={formData.city}
                   onChange={(e) => updateField('city', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                 />
               </div>
             </div>
@@ -749,7 +766,7 @@ export default function SubmitEventPage() {
               <select
                 value={formData.category}
                 onChange={(e) => updateField('category', e.target.value)}
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               >
                 {Object.entries(categoryLabels).map(([value, label]) => (
                   <option key={value} value={value}>
@@ -767,7 +784,7 @@ export default function SubmitEventPage() {
                   id="isFree"
                   checked={formData.isFree}
                   onChange={(e) => updateField('isFree', e.target.checked)}
-                  className="rounded border-stone-300 text-orange-500 focus:ring-orange-500"
+                  className="rounded border-stone-300 text-[#D4622A] focus:ring-[#D4622A]"
                 />
                 <label htmlFor="isFree" className="text-sm text-stone-700">
                   This is a free event
@@ -779,7 +796,7 @@ export default function SubmitEventPage() {
                   placeholder="e.g., $20, $15-$30, Free"
                   value={formData.price}
                   onChange={(e) => updateField('price', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                 />
               )}
             </div>
@@ -791,7 +808,7 @@ export default function SubmitEventPage() {
                 id="isFamilyFriendly"
                 checked={formData.isFamilyFriendly}
                 onChange={(e) => updateField('isFamilyFriendly', e.target.checked)}
-                className="rounded border-stone-300 text-orange-500 focus:ring-orange-500"
+                className="rounded border-stone-300 text-[#D4622A] focus:ring-[#D4622A]"
               />
               <label htmlFor="isFamilyFriendly" className="text-sm text-stone-700">
                 Family-friendly event
@@ -808,7 +825,7 @@ export default function SubmitEventPage() {
                 value={formData.sourceUrl}
                 onChange={(e) => updateField('sourceUrl', e.target.value)}
                 placeholder="https://..."
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
               />
             </div>
 
@@ -830,7 +847,7 @@ export default function SubmitEventPage() {
                   }}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                     uploadMode === 'url'
-                      ? 'bg-orange-500 text-white'
+                      ? 'bg-[#D4622A] text-[#FEF0E6]'
                       : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
                   }`}
                 >
@@ -844,7 +861,7 @@ export default function SubmitEventPage() {
                   }}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                     uploadMode === 'file'
-                      ? 'bg-orange-500 text-white'
+                      ? 'bg-[#D4622A] text-[#FEF0E6]'
                       : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
                   }`}
                 >
@@ -860,7 +877,7 @@ export default function SubmitEventPage() {
                     value={formData.imageUrl}
                     onChange={(e) => updateField('imageUrl', e.target.value)}
                     placeholder="https://example.com/image.jpg"
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-[#DDD6C6] rounded-xl focus:outline-none focus:ring-2 focus:ring-[#D4622A]"
                   />
                   <p className="text-xs text-stone-500 mt-1">
                     Paste a link to an image for your event
@@ -878,8 +895,8 @@ export default function SubmitEventPage() {
                     onDrop={handleDrop}
                     className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
                       dragActive
-                        ? 'border-orange-500 bg-orange-50'
-                        : 'border-stone-300 hover:border-orange-400'
+                        ? 'border-[#D4622A] bg-[#FDF8F0]'
+                        : 'border-stone-300 hover:border-[#D4622A]'
                     }`}
                   >
                     <input
@@ -911,7 +928,7 @@ export default function SubmitEventPage() {
                                 setSelectedFile(null)
                                 setPreviewUrl('')
                               }}
-                              className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                              className="text-sm text-[#D4622A] hover:text-[#7A7468] font-medium"
                             >
                               Choose Different File
                             </button>
@@ -943,7 +960,7 @@ export default function SubmitEventPage() {
 
               {/* Upload Progress */}
               {uploadProgress && (
-                <div className="mt-3 bg-orange-50 border border-orange-200 text-orange-700 px-4 py-3 rounded-lg flex items-center gap-2">
+                <div className="mt-3 bg-orange-50 border border-[#DDD6C6] text-[#7A7468] px-4 py-3 rounded-lg flex items-center gap-2">
                   <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
@@ -975,20 +992,22 @@ export default function SubmitEventPage() {
             <button
               type="submit"
               disabled={saving}
-              className="flex-1 px-6 py-3 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 disabled:opacity-50 transition-colors"
+              style={{ flex: 1, padding: '12px 22px', background: '#D4622A', color: '#FEF0E6', borderRadius: 20, border: 'none', cursor: 'pointer', fontWeight: 500, fontSize: 13.5, fontFamily: 'inherit', opacity: saving ? 0.6 : 1 }}
             >
-              {saving ? 'Submitting...' : 'Submit Event for Review'}
+              {saving ? 'Submitting...' : 'Submit event →'}
             </button>
             <Link
               href="/"
-              className="px-6 py-3 bg-stone-100 text-stone-700 rounded-lg font-medium hover:bg-stone-200 transition-colors flex items-center"
+              style={{ padding: '12px 22px', background: 'transparent', color: '#7A7468', border: '0.5px solid #DDD6C6', borderRadius: 20, fontWeight: 500, fontSize: 13, textDecoration: 'none', display: 'flex', alignItems: 'center' }}
             >
               Cancel
             </Link>
           </div>
         </form>
+        </div>
       </main>
 
+      <Footer />
       <BottomNav />
     </div>
   )

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -1,98 +1,120 @@
 import { Activity } from '@prisma/client'
-import type { Category } from '@prisma/client'
-import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
+import { categoryLabels, categoryHexColors } from '@/lib/utils/categories'
 import Link from 'next/link'
-import {
-  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
-  Trophy, Building2, Palette, GraduationCap, Calendar,
-} from 'lucide-react'
-
-const categoryLucideIcons: Record<Category, React.ReactNode> = {
-  MUSIC:                <Music className="w-8 h-8 text-white" />,
-  COMEDY:               <Laugh className="w-8 h-8 text-white" />,
-  MOVIES:               <Film className="w-8 h-8 text-white" />,
-  THEATER:              <Mic2 className="w-8 h-8 text-white" />,
-  FAMILY_KIDS:          <Baby className="w-8 h-8 text-white" />,
-  FOOD_DRINK:           <UtensilsCrossed className="w-8 h-8 text-white" />,
-  SPORTS_RECREATION:    <Trophy className="w-8 h-8 text-white" />,
-  COMMUNITY_GOVERNMENT: <Building2 className="w-8 h-8 text-white" />,
-  ART_GALLERIES:        <Palette className="w-8 h-8 text-white" />,
-  CLASSES_WORKSHOPS:    <GraduationCap className="w-8 h-8 text-white" />,
-  OTHER:                <Calendar className="w-8 h-8 text-white" />,
-}
+import CatIcon from './CatIcon'
 
 interface ActivityCardProps {
   activity: Activity
+  compact?: boolean
 }
 
-export default function ActivityCard({ activity }: ActivityCardProps) {
-  const categoryLabel = categoryLabels[activity.category]
-  const categoryColor = getCategoryColor(activity.category)
+export default function ActivityCard({ activity, compact = false }: ActivityCardProps) {
+  const label = categoryLabels[activity.category]
+  const color = categoryHexColors[activity.category]
+
+  const content = (
+    <>
+      {/* Header area with category icon */}
+      {!compact && (
+        <div style={{
+          height: 140,
+          background: color + '14',
+          backgroundImage: `repeating-linear-gradient(135deg, ${color}10 0 6px, transparent 6px 14px)`,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          position: 'relative',
+          overflow: 'hidden',
+        }}>
+          {activity.imageUrl ? (
+            <img src={activity.imageUrl} alt={activity.title} style={{ width: '100%', height: '100%', objectFit: 'cover', position: 'absolute', inset: 0 }} />
+          ) : (
+            <div style={{ width: 56, height: 56, borderRadius: '50%', background: color, color: '#FEF0E6', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <CatIcon category={activity.category} size={26} color="#FEF0E6" />
+            </div>
+          )}
+          <div style={{ position: 'absolute', bottom: 10, left: 14, fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color, fontWeight: 500 }}>
+            {label.toLowerCase()}.jpg
+          </div>
+        </div>
+      )}
+
+      {/* Body */}
+      <div style={{ padding: compact ? '14px 16px' : 18, display: 'flex', flexDirection: 'column', gap: 8, flex: 1 }}>
+        {compact && (
+          <div style={{ width: 36, height: 36, borderRadius: 10, background: color + '18', color, display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 4 }}>
+            <CatIcon category={activity.category} size={18} color={color} />
+          </div>
+        )}
+
+        <h3 style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: compact ? 16 : 18,
+          fontWeight: 600, color: '#1A1A14',
+          letterSpacing: '-0.01em', lineHeight: 1.2, margin: 0,
+        }}>
+          {activity.title}
+        </h3>
+
+        <div style={{ fontSize: 11.5, color: '#7A7468', letterSpacing: '0.04em' }}>
+          {activity.venue}
+          {activity.city !== 'Nyack' && ` · ${activity.city}`}
+        </div>
+
+        {activity.description && (
+          <p style={{ fontSize: 13, color: '#3A3A2A', lineHeight: 1.55, margin: 0 }}>
+            {activity.description}
+          </p>
+        )}
+
+        {activity.hours && (
+          <p style={{ fontSize: 12, color: '#7A7468', margin: 0 }}>{activity.hours}</p>
+        )}
+
+        <div style={{ display: 'flex', gap: 6, marginTop: 'auto', paddingTop: 6, flexWrap: 'wrap' }}>
+          {activity.isFree && (
+            <span style={{ fontSize: 10, padding: '3px 9px', borderRadius: 10, background: '#E8EFE0', color: '#1E3A2F', fontWeight: 500, border: '0.5px solid #C8DFBE' }}>
+              Free
+            </span>
+          )}
+          {!activity.isFree && activity.price && (
+            <span style={{ fontSize: 10, padding: '3px 9px', borderRadius: 10, background: '#F5F0E8', color: '#3A3A2A', fontWeight: 500, border: '0.5px solid #DDD6C6' }}>
+              {activity.price}
+            </span>
+          )}
+          {activity.isFamilyFriendly && (
+            <span style={{ fontSize: 10, padding: '3px 9px', borderRadius: 10, background: '#E5ECF3', color: '#3A5577', fontWeight: 500, border: '0.5px solid #C0D0DF' }}>
+              Family
+            </span>
+          )}
+        </div>
+      </div>
+    </>
+  )
 
   return (
     <Link
       href={activity.websiteUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="block bg-white rounded-xl border border-stone-200 p-4 hover:shadow-md hover:border-orange-200 transition-all"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#FDF8F0',
+        border: '0.5px solid #DDD6C6',
+        borderRadius: 16,
+        overflow: 'hidden',
+        textDecoration: 'none',
+        transition: 'all 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = 'translateY(-2px)'
+        e.currentTarget.style.borderColor = color + '50'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'translateY(0)'
+        e.currentTarget.style.borderColor = '#DDD6C6'
+      }}
     >
-      <div className="flex gap-4">
-        {/* Activity image or category icon fallback */}
-        {activity.imageUrl ? (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-stone-100">
-            <img
-              src={activity.imageUrl}
-              alt={activity.title}
-              className="w-full h-full object-cover"
-            />
-          </div>
-        ) : (
-          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[activity.category]}`}>
-            {categoryLucideIcons[activity.category]}
-          </div>
-        )}
-
-        <div className="flex-1 min-w-0">
-          {/* Title */}
-          <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
-            {activity.title}
-          </h3>
-
-          {/* Hours */}
-          {activity.hours && (
-            <p className="text-sm text-stone-600 mt-1">
-              {activity.hours}
-            </p>
-          )}
-
-          {/* Venue and location */}
-          <p className="text-sm text-stone-500 mt-0.5">
-            {activity.venue}
-            {activity.city !== 'Nyack' && <span> · {activity.city}</span>}
-          </p>
-
-          {/* Bottom row: category, price, badges */}
-          <div className="flex flex-wrap items-center gap-2 mt-2">
-            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${categoryColor}`}>
-              {categoryLabel}
-            </span>
-
-            {activity.isFree ? (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
-                Free
-              </span>
-            ) : activity.price ? (
-              <span className="text-xs text-stone-500">{activity.price}</span>
-            ) : null}
-
-            {activity.isFamilyFriendly && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
-                Family
-              </span>
-            )}
-          </div>
-        </div>
-      </div>
+      {content}
     </Link>
   )
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -11,53 +11,45 @@ export default function BottomNav() {
 
   return (
     <>
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-stone-200 px-4 py-2 z-50">
-        <div className="flex justify-around">
+      <nav
+        className="md:hidden fixed bottom-0 left-0 right-0 z-50"
+        style={{ background: '#1E3A2F', borderTop: '0.5px solid rgba(245,240,232,0.15)' }}
+      >
+        <div className="flex justify-around px-4 py-2">
           <Link
             href="/"
-            className={`flex flex-col items-center py-2 px-4 ${
-              isEventsActive ? 'text-orange-500' : 'text-stone-500'
-            }`}
+            className="flex flex-col items-center py-2 px-4"
+            style={{ color: isEventsActive ? '#D4622A' : '#8FBD9E', textDecoration: 'none' }}
           >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-              />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
             </svg>
-            <span className="text-xs mt-1">Events</span>
+            <span className="text-xs mt-1" style={{ fontWeight: isEventsActive ? 500 : 400 }}>Events</span>
           </Link>
           <Link
             href="/activities"
-            className={`flex flex-col items-center py-2 px-4 ${
-              isActivitiesActive ? 'text-orange-500' : 'text-stone-500'
-            }`}
+            className="flex flex-col items-center py-2 px-4"
+            style={{ color: isActivitiesActive ? '#D4622A' : '#8FBD9E', textDecoration: 'none' }}
           >
-            <svg
-              className="w-6 h-6"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
-              />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8}
+                d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z" />
             </svg>
-            <span className="text-xs mt-1">Activities</span>
+            <span className="text-xs mt-1" style={{ fontWeight: isActivitiesActive ? 500 : 400 }}>Always On</span>
+          </Link>
+          <Link
+            href="/submit"
+            className="flex flex-col items-center py-2 px-4"
+            style={{ color: '#8FBD9E', textDecoration: 'none' }}
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.8} d="M12 4v16m8-8H4" />
+            </svg>
+            <span className="text-xs mt-1">Submit</span>
           </Link>
         </div>
       </nav>
-      {/* Spacer for mobile bottom nav */}
       <div className="h-16 md:hidden" />
     </>
   )

--- a/src/components/CalendarDropdown.tsx
+++ b/src/components/CalendarDropdown.tsx
@@ -57,7 +57,10 @@ export default function CalendarDropdown({ event }: CalendarDropdownProps) {
           e.stopPropagation()
           setIsOpen(!isOpen)
         }}
-        className="px-2 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-700 hover:bg-orange-200 transition-colors"
+        className="px-2 py-0.5 rounded-full text-xs font-medium transition-colors"
+        style={{ background: '#EBF0EC', color: '#1E3A2F' }}
+        onMouseEnter={(e) => (e.currentTarget.style.background = '#D4E2D8')}
+        onMouseLeave={(e) => (e.currentTarget.style.background = '#EBF0EC')}
         aria-label="Add to calendar"
         aria-expanded={isOpen}
       >
@@ -71,7 +74,7 @@ export default function CalendarDropdown({ event }: CalendarDropdownProps) {
         >
           <button
             onClick={handleGoogleCalendar}
-            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-orange-50 rounded-t-lg transition-colors"
+            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 rounded-t-lg transition-colors"
             role="menuitem"
           >
             Google Calendar
@@ -79,7 +82,7 @@ export default function CalendarDropdown({ event }: CalendarDropdownProps) {
 
           <button
             onClick={handleDownloadICS}
-            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-orange-50 transition-colors"
+            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 transition-colors"
             role="menuitem"
           >
             Apple Calendar
@@ -87,7 +90,7 @@ export default function CalendarDropdown({ event }: CalendarDropdownProps) {
 
           <button
             onClick={handleDownloadICS}
-            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-orange-50 transition-colors"
+            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 transition-colors"
             role="menuitem"
           >
             Outlook
@@ -95,7 +98,7 @@ export default function CalendarDropdown({ event }: CalendarDropdownProps) {
 
           <button
             onClick={handleDownloadICS}
-            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-orange-50 rounded-b-lg transition-colors"
+            className="w-full text-left px-4 py-2 text-sm text-stone-700 hover:bg-stone-50 rounded-b-lg transition-colors"
             role="menuitem"
           >
             Download ICS

--- a/src/components/CatIcon.tsx
+++ b/src/components/CatIcon.tsx
@@ -1,0 +1,38 @@
+import { Category } from '@prisma/client'
+
+interface CatIconProps {
+  category: Category
+  size?: number
+  color?: string
+}
+
+export default function CatIcon({ category, size = 20, color = 'currentColor' }: CatIconProps) {
+  const s = size
+  const c = color
+  const stroke = { stroke: c, strokeWidth: 1.6, fill: 'none', strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }
+
+  switch (category) {
+    case 'MUSIC':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M9 18V5l10-2v13" /><circle cx="6" cy="18" r="3" /><circle cx="16" cy="16" r="3" /></svg>)
+    case 'FOOD_DRINK':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M6 3v6a3 3 0 003 3v9" /><path d="M12 3v18" /><path d="M18 3v6c0 1.5-1 3-3 3" /></svg>)
+    case 'ART_GALLERIES':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><circle cx="12" cy="12" r="9" /><circle cx="9" cy="9" r="1.2" fill={c} /><circle cx="15" cy="9" r="1.2" fill={c} /><circle cx="16.5" cy="13" r="1.2" fill={c} /><path d="M12 21a3 3 0 003-3c0-2-3-2-3-4" /></svg>)
+    case 'FAMILY_KIDS':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><circle cx="9" cy="8" r="3" /><circle cx="17" cy="9" r="2.5" /><path d="M3 20c.5-3.5 3-5.5 6-5.5s5.5 2 6 5.5" /><path d="M14 20c.4-2.5 2-4 3.5-4s2.5 1.2 3 3" /></svg>)
+    case 'COMEDY':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><circle cx="12" cy="12" r="9" /><path d="M8 14c1 2 2.5 3 4 3s3-1 4-3" /><path d="M8.5 9.5l1 1M14.5 10.5l1-1" /></svg>)
+    case 'MOVIES':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><rect x="3" y="5" width="18" height="14" rx="1.5" /><path d="M7 5v14M17 5v14M3 9h4M17 9h4M3 15h4M17 15h4" /></svg>)
+    case 'THEATER':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M4 4h16v8a8 8 0 01-16 0z" /><circle cx="9" cy="10" r="0.8" fill={c} /><circle cx="15" cy="10" r="0.8" fill={c} /><path d="M9 14c1 1 2 1.5 3 1.5s2-.5 3-1.5" /></svg>)
+    case 'SPORTS_RECREATION':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M3 20l5-9 4 6 3-4 6 7" /><circle cx="17" cy="6" r="2" /></svg>)
+    case 'COMMUNITY_GOVERNMENT':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M3 20h18" /><path d="M5 20V10l7-5 7 5v10" /><path d="M9 20v-5h6v5" /></svg>)
+    case 'CLASSES_WORKSHOPS':
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><path d="M3 6l9-3 9 3-9 3z" /><path d="M7 8v5c0 2 2.5 3 5 3s5-1 5-3V8" /></svg>)
+    default:
+      return (<svg width={s} height={s} viewBox="0 0 24 24" {...stroke}><rect x="4" y="5" width="16" height="15" rx="2" /><path d="M4 9h16M9 3v4M15 3v4" /></svg>)
+  }
+}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,122 +1,65 @@
 import { Event } from '@prisma/client'
-import type { Category } from '@prisma/client'
 import { formatTime, formatDate } from '@/lib/utils/dates'
-import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
+import { categoryLabels, categoryHexColors } from '@/lib/utils/categories'
 import { decodeHtmlEntities } from '@/lib/utils/text'
 import Link from 'next/link'
 import CalendarDropdown from './CalendarDropdown'
-import {
-  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
-  Trophy, Building2, Palette, GraduationCap, Calendar,
-} from 'lucide-react'
-
-const categoryLucideIcons: Record<Category, React.ReactNode> = {
-  MUSIC:                <Music className="w-8 h-8 text-white" />,
-  COMEDY:               <Laugh className="w-8 h-8 text-white" />,
-  MOVIES:               <Film className="w-8 h-8 text-white" />,
-  THEATER:              <Mic2 className="w-8 h-8 text-white" />,
-  FAMILY_KIDS:          <Baby className="w-8 h-8 text-white" />,
-  FOOD_DRINK:           <UtensilsCrossed className="w-8 h-8 text-white" />,
-  SPORTS_RECREATION:    <Trophy className="w-8 h-8 text-white" />,
-  COMMUNITY_GOVERNMENT: <Building2 className="w-8 h-8 text-white" />,
-  ART_GALLERIES:        <Palette className="w-8 h-8 text-white" />,
-  CLASSES_WORKSHOPS:    <GraduationCap className="w-8 h-8 text-white" />,
-  OTHER:                <Calendar className="w-8 h-8 text-white" />,
-}
 
 interface EventCardProps {
   event: Event
   showDate?: boolean
+  isLast?: boolean
 }
 
-export default function EventCard({ event, showDate = false }: EventCardProps) {
+export default function EventCard({ event, showDate = false, isLast = false }: EventCardProps) {
   const startDate = new Date(event.startDate)
-  const categoryLabel = categoryLabels[event.category]
-  const categoryColor = getCategoryColor(event.category)
+  const label = categoryLabels[event.category]
+  const dotColor = categoryHexColors[event.category]
   const title = decodeHtmlEntities(event.title)
+  const venue = decodeHtmlEntities(event.venue)
 
   return (
     <Link
       href={event.sourceUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className={`block rounded-xl border p-4 transition-all ${
-        event.isMarquee
-          ? 'bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400'
-          : 'bg-white border-stone-200 hover:shadow-md hover:border-orange-200'
-      }`}
+      className="group no-underline"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '14px 18px',
+        borderBottom: isLast ? 'none' : '0.5px solid #EBE4D4',
+        textDecoration: 'none',
+        transition: 'background 0.12s',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = '#F5EFE3')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
     >
-      <div className="flex gap-4">
-        {/* Event image or category icon fallback */}
-        {event.imageUrl ? (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-stone-100">
-            <img
-              src={event.imageUrl}
-              alt={title}
-              className="w-full h-full object-cover"
-            />
-          </div>
-        ) : (
-          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[event.category]}`}>
-            {categoryLucideIcons[event.category]}
-          </div>
+      {/* Category dot */}
+      <div style={{ width: 10, height: 10, borderRadius: '50%', background: dotColor, flexShrink: 0 }} />
+
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 13.5, fontWeight: 500, color: '#1A1A14',
+          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 11.5, color: '#7A7468', marginTop: 2 }}>
+          {label} · {venue}
+          {event.city !== 'Nyack' ? ` · ${event.city}` : ''}
+          {event.isFree ? ' · Free' : event.price ? ` · ${event.price}` : ''}
+        </div>
+      </div>
+
+      <div style={{ fontSize: 11.5, color: '#7A7468', textAlign: 'right', flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
+        {showDate && (
+          <div style={{ fontWeight: 500, color: '#1A1A14' }}>{formatDate(startDate)}</div>
         )}
-
-        <div className="flex-1 min-w-0">
-          {/* Title */}
-          <div className="flex items-center gap-2">
-            <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
-              {title}
-            </h3>
-            {event.isMarquee && (
-              <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-200 text-amber-800">
-                ⭐ Big Event
-              </span>
-            )}
-          </div>
-
-          {/* Time and date */}
-          <p className="text-sm text-stone-600 mt-1">
-            {showDate && <span>{formatDate(startDate)} · </span>}
-            {formatTime(startDate)}
-          </p>
-
-          {/* Venue and location */}
-          <p className="text-sm text-stone-500 mt-0.5">
-            {event.venue}
-            {event.city !== 'Nyack' && <span> · {event.city}</span>}
-          </p>
-
-          {/* Bottom row: category, price, badges */}
-          <div className="flex flex-wrap items-center gap-2 mt-2">
-            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${categoryColor}`}>
-              {categoryLabel}
-            </span>
-
-            {event.isFree ? (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
-                Free
-              </span>
-            ) : event.price ? (
-              <span className="text-xs text-stone-500">{event.price}</span>
-            ) : null}
-
-            {event.isFamilyFriendly && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
-                Family
-              </span>
-            )}
-
-            {event.isRecurring && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">
-                🔁 Recurring
-              </span>
-            )}
-
-            <div onClick={(e) => e.stopPropagation()}>
-              <CalendarDropdown event={event} />
-            </div>
-          </div>
+        <div>{formatTime(startDate)}</div>
+        <div onClick={(e) => e.stopPropagation()}>
+          <CalendarDropdown event={event} />
         </div>
       </div>
     </Link>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -26,8 +26,8 @@ export default function EventCard({ event, showDate = false, isLast = false }: E
       className="group no-underline"
       style={{
         display: 'flex',
-        alignItems: 'center',
-        gap: 14,
+        alignItems: 'flex-start',
+        gap: 12,
         padding: '14px 18px',
         borderBottom: isLast ? 'none' : '0.5px solid #EBE4D4',
         textDecoration: 'none',
@@ -36,29 +36,28 @@ export default function EventCard({ event, showDate = false, isLast = false }: E
       onMouseEnter={(e) => (e.currentTarget.style.background = '#F5EFE3')}
       onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
     >
-      {/* Category dot */}
-      <div style={{ width: 10, height: 10, borderRadius: '50%', background: dotColor, flexShrink: 0 }} />
+      {/* Category dot — vertically centered with first line of text */}
+      <div style={{ width: 10, height: 10, borderRadius: '50%', background: dotColor, flexShrink: 0, marginTop: 3 }} />
 
+      {/* Content: title row with time, then subtitle, then calendar */}
       <div style={{ flex: 1, minWidth: 0 }}>
-        <div style={{
-          fontSize: 13.5, fontWeight: 500, color: '#1A1A14',
-          overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
-        }}>
-          {title}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 8 }}>
+          <div style={{ fontSize: 13.5, fontWeight: 500, color: '#1A1A14', lineHeight: 1.35 }}>
+            {title}
+          </div>
+          <div style={{ fontSize: 11.5, color: '#7A7468', textAlign: 'right', flexShrink: 0, whiteSpace: 'nowrap' }}>
+            {showDate && <div style={{ fontWeight: 500, color: '#1A1A14' }}>{formatDate(startDate)}</div>}
+            <div>{formatTime(startDate)}</div>
+          </div>
         </div>
+
         <div style={{ fontSize: 11.5, color: '#7A7468', marginTop: 2 }}>
           {label} · {venue}
           {event.city !== 'Nyack' ? ` · ${event.city}` : ''}
           {event.isFree ? ' · Free' : event.price ? ` · ${event.price}` : ''}
         </div>
-      </div>
 
-      <div style={{ fontSize: 11.5, color: '#7A7468', textAlign: 'right', flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
-        {showDate && (
-          <div style={{ fontWeight: 500, color: '#1A1A14' }}>{formatDate(startDate)}</div>
-        )}
-        <div>{formatTime(startDate)}</div>
-        <div onClick={(e) => e.stopPropagation()}>
+        <div style={{ marginTop: 6 }} onClick={(e) => e.stopPropagation()}>
           <CalendarDropdown event={event} />
         </div>
       </div>

--- a/src/components/EventCardSkeleton.tsx
+++ b/src/components/EventCardSkeleton.tsx
@@ -1,38 +1,31 @@
-/**
- * Skeleton loading state for EventCard
- */
 export default function EventCardSkeleton() {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-stone-100 p-4 animate-pulse">
-      <div className="flex gap-4">
-        {/* Image skeleton */}
-        <div className="w-20 h-20 bg-stone-200 rounded-lg flex-shrink-0" />
-
-        {/* Content skeleton */}
-        <div className="flex-1 min-w-0">
-          {/* Title */}
-          <div className="h-5 bg-stone-200 rounded w-3/4 mb-2" />
-
-          {/* Time and venue */}
-          <div className="h-4 bg-stone-100 rounded w-1/2 mb-2" />
-
-          {/* Tags row */}
-          <div className="flex gap-2 mt-2">
-            <div className="h-5 bg-stone-100 rounded w-16" />
-            <div className="h-5 bg-stone-100 rounded w-12" />
-          </div>
-        </div>
+    <div
+      className="animate-pulse"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        padding: '14px 18px',
+        borderBottom: '0.5px solid #EBE4D4',
+      }}
+    >
+      <div style={{ width: 10, height: 10, borderRadius: '50%', background: '#DDD6C6', flexShrink: 0 }} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ height: 14, background: '#E8E2D4', borderRadius: 4, width: '60%', marginBottom: 6 }} />
+        <div style={{ height: 11, background: '#EDE8DC', borderRadius: 4, width: '40%' }} />
+      </div>
+      <div style={{ width: 48, display: 'flex', flexDirection: 'column', gap: 4 }}>
+        <div style={{ height: 11, background: '#E8E2D4', borderRadius: 4 }} />
+        <div style={{ height: 11, background: '#EDE8DC', borderRadius: 4 }} />
       </div>
     </div>
   )
 }
 
-/**
- * Multiple skeleton cards for loading state
- */
 export function EventListSkeleton({ count = 5 }: { count?: number }) {
   return (
-    <div className="space-y-3">
+    <div style={{ background: '#FDF8F0', border: '0.5px solid #DDD6C6', borderRadius: 16, overflow: 'hidden' }}>
       {Array.from({ length: count }).map((_, i) => (
         <EventCardSkeleton key={i} />
       ))}

--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -10,24 +10,42 @@ interface EventListProps {
 export default function EventList({
   events,
   showDate = false,
-  emptyMessage = "No events found",
+  emptyMessage = 'No events found',
 }: EventListProps) {
   if (events.length === 0) {
     return (
-      <div className="text-center py-12">
-        <div className="text-4xl mb-4">🌙</div>
-        <p className="text-stone-500">{emptyMessage}</p>
-        <p className="text-sm text-stone-400 mt-2">
-          Check back later or try a different filter
-        </p>
+      <div
+        style={{
+          background: '#FDF8F0',
+          border: '0.5px dashed #DDD6C6',
+          borderRadius: 16,
+          padding: 40,
+          textAlign: 'center',
+          color: '#7A7468',
+          fontSize: 13,
+        }}
+      >
+        {emptyMessage}
       </div>
     )
   }
 
   return (
-    <div className="space-y-3">
-      {events.map((event) => (
-        <EventCard key={event.id} event={event} showDate={showDate} />
+    <div
+      style={{
+        background: '#FDF8F0',
+        border: '0.5px solid #DDD6C6',
+        borderRadius: 16,
+        overflow: 'hidden',
+      }}
+    >
+      {events.map((event, i) => (
+        <EventCard
+          key={event.id}
+          event={event}
+          showDate={showDate}
+          isLast={i === events.length - 1}
+        />
       ))}
     </div>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link'
+
+const discoverLinks = [
+  { label: "Today's events", href: '/' },
+  { label: 'Always-on', href: '/activities' },
+  { label: 'Submit event', href: '/submit' },
+]
+
+const aboutLinks = [
+  { label: 'Newsletter', href: '/#subscribe-section' },
+  { label: 'Contact', href: 'mailto:hello@nyacktoday.com' },
+]
+
+export default function Footer() {
+  return (
+    <footer style={{ background: '#1E3A2F', color: '#8FBD9E' }}>
+      <div
+        className="max-w-[1100px] mx-auto"
+        style={{ padding: 'clamp(32px, 5vw, 48px) clamp(20px, 4vw, 48px) 32px' }}
+      >
+        <div className="flex flex-col md:flex-row gap-10 md:gap-12 justify-between items-start">
+          <div style={{ maxWidth: 320 }}>
+            <div style={{
+              fontFamily: 'var(--font-display)',
+              fontSize: 22, fontWeight: 600, color: '#F5F0E8', letterSpacing: '-0.01em',
+              marginBottom: 14,
+            }}>
+              Nyack Today
+            </div>
+            <p style={{ fontSize: 12, color: '#8FBD9E', lineHeight: 1.6 }}>
+              A community events guide for Nyack and the surrounding Hudson Valley.
+              Independently maintained — submit anything we&rsquo;re missing.
+            </p>
+          </div>
+
+          <div className="flex gap-10 md:gap-14 flex-wrap">
+            <FooterCol title="Discover" links={discoverLinks} />
+            <FooterCol title="About" links={aboutLinks} />
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 40,
+            paddingTop: 20,
+            borderTop: '0.5px solid rgba(245,240,232,0.12)',
+            display: 'flex',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: 12,
+            fontSize: 11,
+            color: '#5C8266',
+            letterSpacing: '0.04em',
+          }}
+        >
+          <span>© {new Date().getFullYear()} Nyack Today</span>
+          <span>Made on the Hudson</span>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+function FooterCol({ title, links }: { title: string; links: { label: string; href: string }[] }) {
+  return (
+    <div>
+      <div style={{
+        fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase',
+        color: '#5C8266', marginBottom: 12, fontWeight: 500,
+      }}>
+        {title}
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {links.map((l) => (
+          <li key={l.label}>
+            <Link href={l.href} style={{ fontSize: 13, color: '#C5DFC9', textDecoration: 'none' }}>
+              {l.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,132 +4,166 @@ import Link from 'next/link'
 import { usePathname, useRouter } from 'next/navigation'
 import { useState } from 'react'
 
+const links = [
+  { href: '/', label: 'Events' },
+  { href: '/activities', label: 'Always On' },
+  { href: '/submit', label: 'Submit' },
+]
+
 export default function Header() {
   const [menuOpen, setMenuOpen] = useState(false)
   const pathname = usePathname()
   const router = useRouter()
 
-  const handleEventsClick = (e: React.MouseEvent) => {
-    e.preventDefault()
-    setMenuOpen(false)
-
-    if (pathname === '/') {
-      const eventsSection = document.getElementById('events-section')
-      eventsSection?.scrollIntoView({ behavior: 'smooth' })
-    } else {
-      router.push('/')
-    }
-  }
-
   const handleSubscribeClick = (e: React.MouseEvent) => {
     e.preventDefault()
     setMenuOpen(false)
-
     if (pathname === '/') {
-      const subscribeSection = document.getElementById('subscribe-section')
-      subscribeSection?.scrollIntoView({ behavior: 'smooth' })
+      document.getElementById('subscribe-section')?.scrollIntoView({ behavior: 'smooth' })
     } else {
       router.push('/#subscribe-section')
     }
   }
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b border-stone-200 shadow-sm">
-      <div className="max-w-4xl mx-auto px-4 py-2 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-2xl font-bold text-orange-500">Nyack</span>
-          <span className="text-2xl font-light text-stone-700">Today</span>
+    <header className="sticky top-0 z-50" style={{ background: '#1E3A2F' }}>
+      <div className="max-w-[1100px] mx-auto px-5 md:px-8 flex items-center justify-between gap-6" style={{ padding: '18px 32px' }}>
+        <Link
+          href="/"
+          className="shrink-0 no-underline"
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 22,
+            fontWeight: 600,
+            color: '#F5F0E8',
+            letterSpacing: '-0.01em',
+            textDecoration: 'none',
+          }}
+        >
+          Nyack Today
         </Link>
 
-        {/* Mobile menu button */}
-        <button
-          onClick={() => setMenuOpen(!menuOpen)}
-          className="md:hidden p-2 text-stone-600 hover:text-stone-900"
-          aria-label="Toggle menu"
-        >
-          <svg
-            className="w-6 h-6"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            {menuOpen ? (
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M6 18L18 6M6 6l12 12"
-              />
-            ) : (
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M4 6h16M4 12h16M4 18h16"
-              />
-            )}
-          </svg>
-        </button>
-
         {/* Desktop nav */}
-        <nav className="hidden md:flex items-center gap-6">
-          <button
-            onClick={handleEventsClick}
-            className="text-stone-600 hover:text-orange-500 transition-colors cursor-pointer"
-          >
-            Events
-          </button>
-          <Link
-            href="/activities"
-            className="text-stone-600 hover:text-orange-500 transition-colors"
-          >
-            Always Available
-          </Link>
-          <Link
-            href="/submit"
-            className="text-stone-600 hover:text-orange-500 transition-colors"
-          >
-            Submit Event
-          </Link>
+        <nav className="hidden md:flex items-center gap-7">
+          {links.map((l) => {
+            const active = l.href === '/' ? pathname === '/' : pathname.startsWith(l.href)
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                style={{
+                  fontSize: 13,
+                  color: active ? '#F5F0E8' : '#8FBD9E',
+                  fontWeight: active ? 500 : 400,
+                  textDecoration: 'none',
+                  paddingBottom: 2,
+                  borderBottom: active ? '1px solid #D4622A' : '1px solid transparent',
+                  transition: 'all 0.15s',
+                }}
+              >
+                {l.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="flex items-center gap-3">
+          {/* Desktop subscribe */}
           <button
             onClick={handleSubscribeClick}
-            className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer"
+            className="hidden md:block"
+            style={{
+              background: '#D4622A',
+              color: '#FEF0E6',
+              fontSize: 12,
+              padding: '8px 16px',
+              borderRadius: 20,
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontFamily: 'inherit',
+            }}
           >
-            Subscribe
+            Subscribe →
           </button>
-        </nav>
+
+          {/* Mobile hamburger */}
+          <button
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label="Menu"
+            className="md:hidden flex items-center justify-center"
+            style={{
+              background: 'transparent',
+              border: '0.5px solid rgba(245,240,232,0.25)',
+              borderRadius: 10,
+              width: 36,
+              height: 36,
+              padding: 0,
+              cursor: 'pointer',
+              color: '#F5F0E8',
+            }}
+          >
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round">
+              {menuOpen
+                ? <><path d="M6 6l12 12" /><path d="M18 6l-12 12" /></>
+                : <><path d="M4 7h16" /><path d="M4 12h16" /><path d="M4 17h16" /></>
+              }
+            </svg>
+          </button>
+        </div>
       </div>
 
-      {/* Mobile nav */}
+      {/* Mobile drawer */}
       {menuOpen && (
-        <nav className="md:hidden border-t border-stone-200 bg-white">
-          <button
-            onClick={handleEventsClick}
-            className="block w-full text-left px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
-          >
-            Events
-          </button>
-          <Link
-            href="/activities"
-            className="block px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
-            onClick={() => setMenuOpen(false)}
-          >
-            Always Available
-          </Link>
-          <Link
-            href="/submit"
-            className="block px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
-            onClick={() => setMenuOpen(false)}
-          >
-            Submit Event
-          </Link>
+        <div
+          className="md:hidden absolute left-0 right-0"
+          style={{
+            background: '#1E3A2F',
+            borderTop: '0.5px solid rgba(245,240,232,0.15)',
+            padding: '8px 20px 16px',
+            zIndex: 10,
+          }}
+        >
+          {links.map((l) => {
+            const active = l.href === '/' ? pathname === '/' : pathname.startsWith(l.href)
+            return (
+              <Link
+                key={l.href}
+                href={l.href}
+                onClick={() => setMenuOpen(false)}
+                style={{
+                  display: 'block',
+                  padding: '12px 4px',
+                  fontSize: 14,
+                  color: active ? '#F5F0E8' : '#8FBD9E',
+                  fontWeight: active ? 500 : 400,
+                  textDecoration: 'none',
+                  borderBottom: '0.5px solid rgba(245,240,232,0.08)',
+                }}
+              >
+                {l.label}
+              </Link>
+            )
+          })}
           <button
             onClick={handleSubscribeClick}
-            className="block w-full text-left px-4 py-3 text-orange-500 hover:bg-orange-50 font-medium"
+            style={{
+              marginTop: 12,
+              width: '100%',
+              background: '#D4622A',
+              color: '#FEF0E6',
+              fontSize: 13,
+              padding: '11px 16px',
+              borderRadius: 20,
+              border: 'none',
+              cursor: 'pointer',
+              fontWeight: 500,
+              fontFamily: 'inherit',
+            }}
           >
-            Subscribe to Weekly Digest
+            Subscribe →
           </button>
-        </nav>
+        </div>
       )}
     </header>
   )

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,21 +1,234 @@
-export default function Hero() {
-  return (
-    <div className="relative">
-      {/* Background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
+'use client'
 
-      {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 pt-10 pb-4 max-w-6xl mx-auto w-full">
-        {/* Hero headline */}
-        <div className="text-center">
-          <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">
-            Nyack Today
-          </h1>
-          <p className="text-lg md:text-xl text-stone-800">
-            Your guide to what&apos;s happening in our corner of the Hudson Valley
-          </p>
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import { DayPicker } from 'react-day-picker'
+import { Drawer } from 'vaul'
+import { DateFilter, formatCustomDatePill, getMaxSelectableDate } from '@/lib/utils/dates'
+import 'react-day-picker/style.css'
+
+const DATE_TABS: { value: DateFilter; label: string }[] = [
+  { value: 'tonight', label: 'Today' },
+  { value: 'tomorrow', label: 'Tomorrow' },
+  { value: 'weekend', label: 'Weekend' },
+  { value: 'week', label: 'This Week' },
+  { value: 'month', label: 'This Month' },
+]
+
+const DATE_PILL_LABELS: Record<DateFilter | 'custom', string> = {
+  tonight: 'Happening today',
+  tomorrow: 'Happening tomorrow',
+  weekend: 'This weekend in Nyack',
+  week: 'Happening this week',
+  month: 'This month in Nyack',
+  custom: 'Custom date',
+}
+
+export const CATEGORY_FILTERS = ['All', 'Music', 'Food & Drink', 'Family', 'Art', 'Community', 'Free', 'Outdoors']
+
+interface HeroProps {
+  dateFilter: DateFilter
+  onDateFilterChange: (filter: DateFilter) => void
+  quickFilter: string
+  onQuickFilterChange: (filter: string) => void
+  customDate: Date | null
+  onCustomDateSelect: (date: Date) => void
+  onCustomDateClear: () => void
+}
+
+export default function Hero({
+  dateFilter,
+  onDateFilterChange,
+  quickFilter,
+  onQuickFilterChange,
+  customDate,
+  onCustomDateSelect,
+  onCustomDateClear,
+}: HeroProps) {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const maxDate = getMaxSelectableDate()
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+
+  const pillLabel = customDate
+    ? formatCustomDatePill(customDate)
+    : DATE_PILL_LABELS[dateFilter]
+
+  const chipBase: React.CSSProperties = {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 6,
+    fontSize: 12,
+    padding: '7px 14px',
+    borderRadius: 20,
+    cursor: 'pointer',
+    border: '0.5px solid',
+    userSelect: 'none',
+    transition: 'all 0.15s',
+    fontWeight: 400,
+    whiteSpace: 'nowrap',
+    fontFamily: 'inherit',
+    background: 'transparent',
+  }
+
+  const chipActive: React.CSSProperties = {
+    background: '#D4622A',
+    color: '#FEF0E6',
+    borderColor: '#D4622A',
+  }
+
+  const chipInactive: React.CSSProperties = {
+    background: 'rgba(245,240,232,0.10)',
+    color: '#C5DFC9',
+    borderColor: 'rgba(245,240,232,0.20)',
+  }
+
+  return (
+    <section
+      style={{
+        background: '#1E3A2F',
+        padding: '56px 32px 56px',
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      {/* Organic blob accent */}
+      <svg
+        width="420"
+        height="420"
+        viewBox="0 0 360 360"
+        style={{ position: 'absolute', right: -80, top: -60, pointerEvents: 'none', opacity: 1 }}
+        aria-hidden="true"
+      >
+        <ellipse cx="180" cy="170" rx="150" ry="115" fill="#8FBD9E" opacity="0.18" transform="rotate(18 180 170)" />
+        <ellipse cx="225" cy="135" rx="80" ry="65" fill="#F5F0E8" opacity="0.12" />
+        <ellipse cx="120" cy="220" rx="50" ry="40" fill="#D4622A" opacity="0.18" />
+        <circle cx="265" cy="220" r="22" fill="#C8973A" opacity="0.25" />
+      </svg>
+
+      <div className="max-w-[1100px] mx-auto" style={{ position: 'relative' }}>
+        {/* Date pill */}
+        <div style={{ marginBottom: 16 }}>
+          <span
+            style={{
+              display: 'inline-block',
+              background: '#D4622A',
+              color: '#FEF0E6',
+              fontSize: 10,
+              letterSpacing: '0.12em',
+              textTransform: 'uppercase',
+              padding: '5px 10px',
+              borderRadius: 12,
+              fontWeight: 500,
+            }}
+          >
+            {pillLabel}
+          </span>
+        </div>
+
+        <h1
+          style={{
+            fontFamily: 'var(--font-display)',
+            fontSize: 'clamp(38px, 5vw, 56px)',
+            fontWeight: 600,
+            color: '#F5F0E8',
+            lineHeight: 1.05,
+            maxWidth: 600,
+            letterSpacing: '-0.025em',
+            marginBottom: 14,
+          }}
+        >
+          What&rsquo;s on in Nyack.
+        </h1>
+
+        <p
+          style={{
+            fontSize: 16,
+            color: '#8FBD9E',
+            maxWidth: 460,
+            lineHeight: 1.55,
+            marginBottom: 28,
+          }}
+        >
+          Your corner of the Hudson Valley — live and local. Updated daily.
+        </p>
+
+        {/* Date chips */}
+        <div className="flex flex-wrap gap-2 mb-3">
+          {DATE_TABS.map((tab) => {
+            const active = !customDate && dateFilter === tab.value
+            return (
+              <button
+                key={tab.value}
+                onClick={() => { onDateFilterChange(tab.value); onCustomDateClear() }}
+                style={{ ...chipBase, ...(active ? chipActive : chipInactive) }}
+              >
+                {tab.label}
+              </button>
+            )
+          })}
+
+          {customDate ? (
+            <div
+              style={{ ...chipBase, ...chipActive, display: 'inline-flex', alignItems: 'center', gap: 4 }}
+            >
+              <span>{formatCustomDatePill(customDate)}</span>
+              <button
+                onClick={onCustomDateClear}
+                aria-label="Clear custom date"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', padding: '0 0 0 4px', color: 'inherit', display: 'flex' }}
+              >
+                <X size={12} />
+              </button>
+            </div>
+          ) : (
+            <Drawer.Root open={drawerOpen} onOpenChange={setDrawerOpen}>
+              <Drawer.Trigger asChild>
+                <button style={{ ...chipBase, ...chipInactive }}>Custom</button>
+              </Drawer.Trigger>
+              <Drawer.Portal>
+                <Drawer.Overlay className="fixed inset-0 bg-black/40 z-40" />
+                <Drawer.Content className="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl z-50 outline-none">
+                  <Drawer.Title className="sr-only">Pick a Date</Drawer.Title>
+                  <div className="pt-3 flex justify-center">
+                    <div className="w-10 h-1 bg-stone-200 rounded-full" />
+                  </div>
+                  <div className="p-4 pb-8">
+                    <h3 className="text-base font-semibold text-stone-900 mb-3 text-center">
+                      Pick a Date
+                    </h3>
+                    <div className="flex justify-center">
+                      <DayPicker
+                        mode="single"
+                        selected={customDate ?? undefined}
+                        onSelect={(date) => { if (date) { onCustomDateSelect(date); setDrawerOpen(false) } }}
+                        disabled={[{ before: today }, { after: maxDate }]}
+                        className="rdp-custom"
+                      />
+                    </div>
+                  </div>
+                </Drawer.Content>
+              </Drawer.Portal>
+            </Drawer.Root>
+          )}
+        </div>
+
+        {/* Category chips */}
+        <div className="flex flex-wrap gap-2">
+          {CATEGORY_FILTERS.map((f) => {
+            const active = quickFilter === f
+            return (
+              <button
+                key={f}
+                onClick={() => onQuickFilterChange(f)}
+                style={{ ...chipBase, ...(active ? chipActive : chipInactive) }}
+              >
+                {f}
+              </button>
+            )
+          })}
         </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/src/components/MarqueeSection.tsx
+++ b/src/components/MarqueeSection.tsx
@@ -1,34 +1,12 @@
 'use client'
 
-import { useEffect, useState, useRef, useCallback } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { Event } from '@prisma/client'
-import type { Category } from '@prisma/client'
 import { formatTime, formatDate } from '@/lib/utils/dates'
-import { categoryLabels, getCategoryColor, categoryGradients } from '@/lib/utils/categories'
+import { categoryLabels, categoryHexColors } from '@/lib/utils/categories'
 import { decodeHtmlEntities } from '@/lib/utils/text'
-import {
-  Music, Laugh, Film, Mic2, Baby, UtensilsCrossed,
-  Trophy, Building2, Palette, GraduationCap, Calendar,
-} from 'lucide-react'
-
-const categoryLucideIcons: Record<Category, React.ReactNode> = {
-  MUSIC:                <Music className="w-10 h-10 text-white" />,
-  COMEDY:               <Laugh className="w-10 h-10 text-white" />,
-  MOVIES:               <Film className="w-10 h-10 text-white" />,
-  THEATER:              <Mic2 className="w-10 h-10 text-white" />,
-  FAMILY_KIDS:          <Baby className="w-10 h-10 text-white" />,
-  FOOD_DRINK:           <UtensilsCrossed className="w-10 h-10 text-white" />,
-  SPORTS_RECREATION:    <Trophy className="w-10 h-10 text-white" />,
-  COMMUNITY_GOVERNMENT: <Building2 className="w-10 h-10 text-white" />,
-  ART_GALLERIES:        <Palette className="w-10 h-10 text-white" />,
-  CLASSES_WORKSHOPS:    <GraduationCap className="w-10 h-10 text-white" />,
-  OTHER:                <Calendar className="w-10 h-10 text-white" />,
-}
-
-interface MarqueeSectionProps {
-  onShowAll: () => void
-}
+import CatIcon from './CatIcon'
 
 function convertDates(events: Event[]): Event[] {
   return events.map((e) => ({
@@ -40,132 +18,195 @@ function convertDates(events: Event[]): Event[] {
   }))
 }
 
-export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
+function FeaturedCard({ event }: { event: Event }) {
+  const color = categoryHexColors[event.category]
+  const label = categoryLabels[event.category]
+  const title = decodeHtmlEntities(event.title)
+  const startDate = new Date(event.startDate)
+
+  return (
+    <Link
+      href={event.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="col-span-full no-underline"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 18,
+        background: '#D4622A',
+        borderRadius: 16,
+        padding: '22px 24px',
+        position: 'relative',
+        overflow: 'hidden',
+        transition: 'transform 0.15s',
+        textDecoration: 'none',
+        gridColumn: '1 / -1',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.transform = 'translateY(-2px)')}
+      onMouseLeave={(e) => (e.currentTarget.style.transform = 'translateY(0)')}
+    >
+      {/* bg circle decoration */}
+      <svg width="180" height="180" viewBox="0 0 180 180" style={{ position: 'absolute', right: -40, top: -40, opacity: 0.12, pointerEvents: 'none' }}>
+        <circle cx="90" cy="90" r="70" fill="#FEF0E6" />
+      </svg>
+
+      {/* Icon circle */}
+      <div style={{
+        width: 60, height: 60,
+        background: 'rgba(255,255,255,0.18)',
+        borderRadius: '50%',
+        flexShrink: 0,
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: '#FEF0E6',
+      }}>
+        {event.imageUrl
+          ? <img src={event.imageUrl} alt="" style={{ width: 60, height: 60, borderRadius: '50%', objectFit: 'cover' }} />
+          : <CatIcon category={event.category} size={26} color="#FEF0E6" />
+        }
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0, position: 'relative' }}>
+        <div style={{ fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color: '#F5C4A8', marginBottom: 4, fontWeight: 500 }}>
+          {label} · {formatDate(startDate)}
+        </div>
+        <div style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 18, fontWeight: 600, color: '#FEF0E6',
+          letterSpacing: '-0.005em', lineHeight: 1.25,
+        }}>
+          {title}
+        </div>
+        <div style={{ fontSize: 12, color: '#F5C4A8', marginTop: 6 }}>
+          {formatTime(startDate)} · {decodeHtmlEntities(event.venue)}
+          {event.isFree ? ' · Free' : event.price ? ` · ${event.price}` : ''}
+        </div>
+      </div>
+
+      <div style={{ position: 'relative', alignSelf: 'flex-start', flexShrink: 0 }}>
+        <span style={{
+          display: 'inline-block',
+          background: '#1E3A2F', color: '#C8973A',
+          fontSize: 10, letterSpacing: '0.12em', textTransform: 'uppercase',
+          padding: '5px 10px', borderRadius: 12, fontWeight: 500,
+        }}>
+          ★ Big event
+        </span>
+      </div>
+    </Link>
+  )
+}
+
+function MarqueeCard({ event }: { event: Event }) {
+  const color = categoryHexColors[event.category]
+  const label = categoryLabels[event.category]
+  const title = decodeHtmlEntities(event.title)
+  const startDate = new Date(event.startDate)
+
+  return (
+    <Link
+      href={event.sourceUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        background: '#FDF8F0',
+        border: '0.5px solid #DDD6C6',
+        borderRadius: 14,
+        padding: 18,
+        textDecoration: 'none',
+        transition: 'all 0.15s',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = 'translateY(-2px)'
+        e.currentTarget.style.borderColor = color + '50'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'translateY(0)'
+        e.currentTarget.style.borderColor = '#DDD6C6'
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 12 }}>
+        <div style={{ width: 28, height: 4, borderRadius: 2, background: color, flexShrink: 0 }} />
+        <span style={{ fontSize: 9, letterSpacing: '0.14em', textTransform: 'uppercase', color: '#7A7468', fontWeight: 500 }}>
+          {label} · {formatDate(startDate)}
+        </span>
+      </div>
+
+      {event.imageUrl && (
+        <div style={{ borderRadius: 10, overflow: 'hidden', marginBottom: 12, aspectRatio: '16/9' }}>
+          <img src={event.imageUrl} alt={title} style={{ width: '100%', height: '100%', objectFit: 'cover' }} />
+        </div>
+      )}
+
+      <div style={{
+        fontFamily: 'var(--font-display)',
+        fontSize: 15, fontWeight: 600, color: '#1A1A14',
+        lineHeight: 1.3, letterSpacing: '-0.005em', marginBottom: 6,
+      }}>
+        {title}
+      </div>
+
+      <div style={{ fontSize: 12, color: '#7A7468', lineHeight: 1.5 }}>
+        {formatTime(startDate)} · {decodeHtmlEntities(event.venue)}
+      </div>
+
+      <div style={{ display: 'flex', gap: 6, marginTop: 12, flexWrap: 'wrap' }}>
+        {event.isFree && (
+          <span style={{ fontSize: 10, padding: '2px 8px', borderRadius: 10, background: '#E8EFE0', color: '#1E3A2F', fontWeight: 500 }}>Free</span>
+        )}
+        {!event.isFree && event.price && (
+          <span style={{ fontSize: 10, padding: '2px 8px', borderRadius: 10, background: '#F5F0E8', color: '#7A7468', fontWeight: 500 }}>{event.price}</span>
+        )}
+        {event.isFamilyFriendly && (
+          <span style={{ fontSize: 10, padding: '2px 8px', borderRadius: 10, background: '#E5ECF3', color: '#3A5577', fontWeight: 500 }}>Family</span>
+        )}
+        {event.isRecurring && (
+          <span style={{ fontSize: 10, padding: '2px 8px', borderRadius: 10, background: '#F5EBD9', color: '#8B6618', fontWeight: 500 }}>↻ Weekly</span>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+export default function MarqueeSection() {
   const [events, setEvents] = useState<Event[]>([])
-  const [atStart, setAtStart] = useState(true)
-  const [atEnd, setAtEnd] = useState(false)
-  const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    fetch('/api/events?marquee=true&limit=9')
+    fetch('/api/events?marquee=true&limit=3')
       .then((r) => r.json())
-      .then((data) => {
-        const evts = convertDates(data.events ?? [])
-        setEvents(evts)
-        setAtEnd(evts.length <= 3)
-      })
+      .then((data) => setEvents(convertDates(data.events ?? [])))
       .catch(() => {})
   }, [])
-
-  const updateArrows = useCallback(() => {
-    const el = scrollRef.current
-    if (!el) return
-    setAtStart(el.scrollLeft <= 4)
-    setAtEnd(el.scrollLeft + el.clientWidth >= el.scrollWidth - 4)
-  }, [])
-
-  const scrollLeft = () => {
-    scrollRef.current?.scrollBy({ left: -scrollRef.current.clientWidth, behavior: 'smooth' })
-  }
-
-  const scrollRight = () => {
-    scrollRef.current?.scrollBy({ left: scrollRef.current.clientWidth, behavior: 'smooth' })
-  }
 
   if (events.length === 0) return null
 
   return (
-    <div className="mb-8 bg-amber-50 border border-amber-200 rounded-2xl p-4">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm font-semibold text-amber-700 uppercase tracking-wide">
-          ⭐ Big Events
-        </h2>
-        <div className="flex items-center gap-3">
-          <button
-            onClick={onShowAll}
-            className="text-sm text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
-          >
-            See all →
-          </button>
-          {events.length > 3 && (
-            <div className="flex gap-1">
-              <button
-                onClick={scrollLeft}
-                disabled={atStart}
-                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
-                aria-label="Previous"
-              >
-                ‹
-              </button>
-              <button
-                onClick={scrollRight}
-                disabled={atEnd}
-                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
-                aria-label="Next"
-              >
-                ›
-              </button>
-            </div>
-          )}
+    <div style={{ marginBottom: 48 }}>
+      {/* Section header */}
+      <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between', marginBottom: 16, gap: 16 }}>
+        <div>
+          <p style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: '#7A7468', marginBottom: 6, fontWeight: 500 }}>
+            Big events
+          </p>
+          <h2 style={{ fontFamily: 'var(--font-display)', fontSize: 22, fontWeight: 600, color: '#1A1A14', letterSpacing: '-0.01em', lineHeight: 1.2, margin: 0 }}>
+            Don&rsquo;t miss
+          </h2>
         </div>
       </div>
 
+      {/* Grid: featured card spans full width, remaining cards in columns */}
       <div
-        ref={scrollRef}
-        onScroll={updateArrows}
-        className="flex gap-3 overflow-x-auto scroll-smooth [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 14,
+        }}
+        className="grid-cols-1 md:grid-cols-2"
       >
-        {events.map((event) => {
-          const title = decodeHtmlEntities(event.title)
-          const label = categoryLabels[event.category]
-          const color = getCategoryColor(event.category)
-          const startDate = new Date(event.startDate)
-
-          return (
-            <Link
-              key={event.id}
-              href={event.sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-shrink-0 w-[calc(33.333%-8px)] min-w-[200px] bg-white border border-amber-200 rounded-xl p-3 hover:shadow-md hover:border-amber-400 transition-all flex flex-col"
-            >
-              {event.imageUrl ? (
-                <div className="w-full aspect-video rounded-lg overflow-hidden bg-stone-100 mb-3">
-                  <img src={event.imageUrl} alt={title} className="w-full h-full object-cover" />
-                </div>
-              ) : (
-                <div className={`w-full aspect-video rounded-lg flex items-center justify-center mb-3 ${categoryGradients[event.category]}`}>
-                  {categoryLucideIcons[event.category]}
-                </div>
-              )}
-
-              <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight text-sm flex-1">
-                {title}
-              </h3>
-              <p className="text-xs text-stone-500 mt-1">
-                {formatDate(startDate)} · {formatTime(startDate)}
-              </p>
-              <p className="text-xs text-stone-500 truncate mt-0.5">
-                {decodeHtmlEntities(event.venue)}
-              </p>
-              <div className="flex items-center gap-1.5 mt-2 flex-wrap">
-                <span className={`px-1.5 py-0.5 text-xs rounded-full font-medium ${color}`}>
-                  {label}
-                </span>
-                {event.isFree && (
-                  <span className="px-1.5 py-0.5 bg-green-100 text-green-700 text-xs rounded-full font-medium">
-                    Free
-                  </span>
-                )}
-                {event.isFamilyFriendly && (
-                  <span className="px-1.5 py-0.5 bg-blue-100 text-blue-700 text-xs rounded-full font-medium">
-                    Family
-                  </span>
-                )}
-              </div>
-            </Link>
-          )
-        })}
+        {events[0] && <FeaturedCard event={events[0]} />}
+        {events.slice(1).map((e) => <MarqueeCard key={e.id} event={e} />)}
       </div>
     </div>
   )

--- a/src/components/SubscribeSection.tsx
+++ b/src/components/SubscribeSection.tsx
@@ -33,47 +33,109 @@ export default function SubscribeSection() {
   }
 
   return (
-    <div className="rounded-2xl bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 p-6">
-      <h2 className="text-xl font-bold text-stone-900 mb-1">Get Nyack in Your Inbox</h2>
-      <p className="text-stone-600 text-sm mb-4">
-        Every Thursday morning, a quick roundup of what&apos;s happening in Nyack this weekend and beyond — straight to your inbox.
-      </p>
+    <div
+      id="subscribe-section"
+      style={{
+        background: '#2C5240',
+        borderRadius: 18,
+        padding: 'clamp(24px, 4vw, 36px) clamp(22px, 4vw, 40px)',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 32,
+        position: 'relative',
+        overflow: 'hidden',
+        flexWrap: 'wrap',
+      }}
+    >
+      {/* Blob decoration */}
+      <svg width="200" height="200" viewBox="0 0 200 200" style={{ position: 'absolute', right: -30, bottom: -50, opacity: 0.18, pointerEvents: 'none' }}>
+        <ellipse cx="100" cy="100" rx="80" ry="60" fill="#8FBD9E" transform="rotate(20 100 100)" />
+        <circle cx="140" cy="80" r="32" fill="#D4622A" />
+      </svg>
 
-      <div aria-live="polite">
+      <div style={{ flex: 1, position: 'relative', zIndex: 1, minWidth: 220 }}>
+        <p style={{ fontSize: 10, letterSpacing: '0.16em', textTransform: 'uppercase', color: '#8FBD9E', marginBottom: 8, fontWeight: 500 }}>
+          Newsletter
+        </p>
+        <h3 style={{
+          fontFamily: 'var(--font-display)',
+          fontSize: 'clamp(22px, 3vw, 26px)',
+          fontWeight: 600,
+          color: '#F5F0E8',
+          letterSpacing: '-0.015em',
+          lineHeight: 1.2,
+          marginBottom: 6,
+        }}>
+          Nyack in your inbox.
+        </h3>
+        <p style={{ fontSize: 13, color: '#8FBD9E', maxWidth: 380, lineHeight: 1.55 }}>
+          Every Thursday morning — what&rsquo;s worth your weekend, hand-picked. No spam, ever.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: 'flex', gap: 8, position: 'relative', zIndex: 1, flexShrink: 0, flexWrap: 'wrap', minWidth: 280 }}
+        aria-live="polite"
+      >
         {status === 'success' ? (
-          <div className="flex items-center gap-2 text-green-700 font-medium">
-            <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-            </svg>
-            You&apos;re subscribed! Check your inbox Thursday morning.
+          <div style={{
+            background: '#F5F0E8', color: '#1E3A2F',
+            borderRadius: 20, padding: '12px 20px',
+            fontSize: 13, fontWeight: 500,
+          }}>
+            ✓ You&rsquo;re subscribed.
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col sm:flex-row gap-2">
+          <>
             <label htmlFor="subscribe-email" className="sr-only">Email address</label>
             <input
               id="subscribe-email"
               type="email"
+              required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
-              required
+              placeholder="you@nyack.com"
               disabled={status === 'loading'}
-              className="flex-1 rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50"
+              style={{
+                flex: 1,
+                minWidth: 200,
+                background: 'rgba(245,240,232,0.10)',
+                border: '0.5px solid rgba(245,240,232,0.25)',
+                color: '#F5F0E8',
+                borderRadius: 20,
+                padding: '11px 16px',
+                fontSize: 13,
+                outline: 'none',
+                fontFamily: 'inherit',
+              }}
             />
             <button
               type="submit"
               disabled={status === 'loading'}
-              className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 whitespace-nowrap"
+              style={{
+                background: '#D4622A',
+                color: '#FEF0E6',
+                fontSize: 13,
+                padding: '11px 18px',
+                borderRadius: 20,
+                border: 'none',
+                cursor: 'pointer',
+                fontWeight: 500,
+                whiteSpace: 'nowrap',
+                fontFamily: 'inherit',
+                opacity: status === 'loading' ? 0.7 : 1,
+              }}
             >
-              {status === 'loading' ? 'Subscribing...' : 'Subscribe'}
+              {status === 'loading' ? 'Subscribing...' : 'Subscribe →'}
             </button>
-          </form>
+          </>
         )}
-
         {status === 'error' && (
-          <p className="mt-2 text-sm text-red-600">{errorMessage}</p>
+          <p style={{ width: '100%', fontSize: 12, color: '#F5C4A8', marginTop: 4 }}>{errorMessage}</p>
         )}
-      </div>
+      </form>
     </div>
   )
 }

--- a/src/lib/utils/categories.ts
+++ b/src/lib/utils/categories.ts
@@ -73,6 +73,20 @@ export const categoryGradients: Record<Category, string> = {
   OTHER:                'bg-gradient-to-br from-stone-400 to-stone-500',
 }
 
+export const categoryHexColors: Record<Category, string> = {
+  MUSIC: '#7C5BA1',
+  COMEDY: '#C8973A',
+  MOVIES: '#A24A3D',
+  THEATER: '#A0506E',
+  FAMILY_KIDS: '#5B7FA6',
+  FOOD_DRINK: '#D4622A',
+  SPORTS_RECREATION: '#4A8C7A',
+  COMMUNITY_GOVERNMENT: '#7A7468',
+  ART_GALLERIES: '#1E3A2F',
+  CLASSES_WORKSHOPS: '#5B7FA6',
+  OTHER: '#7A7468',
+}
+
 export function getCategoryColor(category: Category): string {
   const colors: Record<Category, string> = {
     MUSIC: 'bg-purple-100 text-purple-800',

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -9,7 +9,6 @@ import { categoryLabels, categoryIcons } from './categories'
 export async function sendEventSubmissionEmail(
   submission: EventSubmission
 ): Promise<void> {
-  // Validate environment variables
   const apiKey = process.env.RESEND_API_KEY
   const adminEmail = process.env.ADMIN_EMAIL
 
@@ -36,7 +35,6 @@ export async function sendEventSubmissionEmail(
 
     console.log(`Event submission email sent for: ${submission.title}`)
   } catch (error) {
-    // Log error but don't throw - email is not critical to submission success
     console.error('Failed to send event submission email:', error)
   }
 }
@@ -45,7 +43,6 @@ function generateHtmlEmail(submission: EventSubmission): string {
   const categoryLabel = categoryLabels[submission.category]
   const categoryIcon = categoryIcons[submission.category]
 
-  // Format dates
   const startDate = new Date(submission.startDate).toLocaleString('en-US', {
     weekday: 'long',
     year: 'numeric',
@@ -73,7 +70,6 @@ function generateHtmlEmail(submission: EventSubmission): string {
     timeStyle: 'short',
   })
 
-  // Format price
   const priceDisplay = submission.isFree
     ? 'Free'
     : submission.price || 'Not specified'
@@ -88,96 +84,114 @@ function generateHtmlEmail(submission: EventSubmission): string {
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
       line-height: 1.6;
-      color: #333;
+      color: #1A1A14;
       max-width: 600px;
       margin: 0 auto;
       padding: 0;
+      background-color: #F5F0E8;
     }
     .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
+      background-color: #1E3A2F;
+      padding: 32px 24px;
       text-align: center;
+    }
+    .header-brand {
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 13px;
+      font-weight: 400;
+      color: #8FBD9E;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 10px;
     }
     .header h1 {
       margin: 0;
-      font-size: 24px;
-      font-weight: 600;
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 26px;
+      font-weight: 700;
+      color: #F5F0E8;
+      letter-spacing: -0.01em;
     }
     .content {
-      padding: 20px;
+      padding: 24px 24px 8px;
+      background: #F5F0E8;
     }
     .event-title {
+      font-family: Georgia, 'Times New Roman', serif;
       font-size: 22px;
       font-weight: 700;
-      color: #1c1917;
+      color: #1A1A14;
       margin: 0 0 20px 0;
+      letter-spacing: -0.01em;
     }
     .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
+      margin: 16px 0;
+      padding: 16px;
+      background: #FDF8F0;
+      border-left: 4px solid #D4622A;
+      border-radius: 6px;
     }
     .section-title {
-      font-size: 14px;
+      font-size: 10px;
       font-weight: 600;
-      color: #57534e;
+      color: #7A7468;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.16em;
       margin: 0 0 12px 0;
     }
     .field {
-      margin-bottom: 12px;
+      margin-bottom: 10px;
     }
     .label {
       font-weight: 600;
-      color: #57534e;
-      margin-right: 8px;
+      color: #7A7468;
+      margin-right: 6px;
+      font-size: 13px;
     }
     .value {
-      color: #1c1917;
+      color: #1A1A14;
+      font-size: 13px;
     }
     .badge {
       display: inline-block;
-      padding: 4px 12px;
-      border-radius: 12px;
-      font-size: 14px;
+      padding: 3px 10px;
+      border-radius: 20px;
+      font-size: 12px;
       font-weight: 500;
-      background-color: #fed7aa;
-      color: #9a3412;
+      background-color: rgba(212, 98, 42, 0.12);
+      color: #D4622A;
     }
     .admin-link {
       display: inline-block;
       margin-top: 20px;
       padding: 12px 24px;
-      background: #f97316;
-      color: white;
+      background: #D4622A;
+      color: #FEF0E6 !important;
       text-decoration: none;
-      border-radius: 8px;
+      border-radius: 20px;
       font-weight: 600;
-    }
-    .admin-link:hover {
-      background: #ea580c;
+      font-size: 13px;
     }
     .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
+      margin-top: 0;
+      padding: 20px 24px;
+      background: #1E3A2F;
       font-size: 12px;
-      color: #78716c;
+      color: #8FBD9E;
+    }
+    .footer strong {
+      color: #C5DFC9;
     }
     a {
-      color: #f97316;
+      color: #D4622A;
       text-decoration: underline;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>📬 New Event Submission</h1>
+    <div class="header-brand">Nyack Today</div>
+    <h1>New Event Submission</h1>
   </div>
 
   <div class="content">
@@ -187,7 +201,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
       <div class="section-title">Required Information</div>
 
       <div class="field">
-        <span class="label">📅 Start Date & Time:</span>
+        <span class="label">Start Date &amp; Time:</span>
         <span class="value">${startDate}</span>
       </div>
 
@@ -195,7 +209,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
         endDate
           ? `
       <div class="field">
-        <span class="label">🏁 End Date & Time:</span>
+        <span class="label">End Date &amp; Time:</span>
         <span class="value">${endDate}</span>
       </div>
       `
@@ -203,7 +217,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
       }
 
       <div class="field">
-        <span class="label">📍 Venue:</span>
+        <span class="label">Venue:</span>
         <span class="value">${escapeHtml(submission.venue)}</span>
       </div>
 
@@ -211,7 +225,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
         submission.address
           ? `
       <div class="field">
-        <span class="label">🗺️ Address:</span>
+        <span class="label">Address:</span>
         <span class="value">${escapeHtml(submission.address)}, ${escapeHtml(submission.city)}</span>
       </div>
       `
@@ -219,7 +233,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
       }
 
       <div class="field">
-        <span class="label">📧 Submitter Email:</span>
+        <span class="label">Submitter Email:</span>
         <span class="value"><a href="mailto:${escapeHtml(submission.submitterEmail)}">${escapeHtml(submission.submitterEmail)}</a></span>
       </div>
     </div>
@@ -239,8 +253,8 @@ function generateHtmlEmail(submission: EventSubmission): string {
         submission.description
           ? `
       <div class="field">
-        <span class="label">📝 Description:</span>
-        <div class="value">${escapeHtml(submission.description).replace(/\n/g, '<br>')}</div>
+        <span class="label">Description:</span>
+        <div class="value" style="margin-top: 4px;">${escapeHtml(submission.description).replace(/\n/g, '<br>')}</div>
       </div>
       `
           : ''
@@ -252,7 +266,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
       </div>
 
       <div class="field">
-        <span class="label">💰 Price:</span>
+        <span class="label">Price:</span>
         <span class="value">${escapeHtml(priceDisplay)}</span>
       </div>
 
@@ -260,7 +274,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
         submission.isFamilyFriendly
           ? `
       <div class="field">
-        <span class="label">👨‍👩‍👧‍👦 Family-Friendly:</span>
+        <span class="label">Family-Friendly:</span>
         <span class="value">Yes</span>
       </div>
       `
@@ -271,7 +285,7 @@ function generateHtmlEmail(submission: EventSubmission): string {
         submission.sourceUrl
           ? `
       <div class="field">
-        <span class="label">🔗 Event URL:</span>
+        <span class="label">Event URL:</span>
         <span class="value"><a href="${escapeHtml(submission.sourceUrl)}" target="_blank">${escapeHtml(submission.sourceUrl)}</a></span>
       </div>
       `
@@ -282,17 +296,17 @@ function generateHtmlEmail(submission: EventSubmission): string {
         : ''
     }
 
-    <div style="text-align: center; margin-top: 30px;">
+    <div style="text-align: center; margin: 24px 0 32px;">
       <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/admin/submissions" class="admin-link">
-        Review Submission in Admin Dashboard
+        Review in Admin Dashboard
       </a>
     </div>
   </div>
 
   <div class="footer">
     <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Submitted:</strong> ${submittedAt}</div>
-    <div><strong>Status:</strong> ${submission.status}</div>
+    <div style="margin-top: 4px;"><strong>Submitted:</strong> ${submittedAt}</div>
+    <div style="margin-top: 4px;"><strong>Status:</strong> ${submission.status}</div>
   </div>
 </body>
 </html>
@@ -382,7 +396,6 @@ function escapeHtml(text: string): string {
 
 /**
  * Format recurrence pattern for display in emails
- * Example: "Repeats every Tuesday, Thursday" or "Repeats every Monday until March 30, 2026"
  */
 function formatRecurrencePattern(
   isRecurring: boolean,
@@ -424,7 +437,6 @@ function generateConfirmationHtmlEmail(submission: EventSubmission): string {
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -442,7 +454,6 @@ function generateConfirmationHtmlEmail(submission: EventSubmission): string {
     })
   }
 
-  // Format time
   const timeDisplay = new Date(submission.startDate).toLocaleString('en-US', {
     hour: 'numeric',
     minute: '2-digit',
@@ -459,64 +470,81 @@ function generateConfirmationHtmlEmail(submission: EventSubmission): string {
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
       line-height: 1.6;
-      color: #333;
+      color: #1A1A14;
       max-width: 600px;
       margin: 0 auto;
       padding: 0;
+      background-color: #F5F0E8;
     }
     .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
+      background-color: #1E3A2F;
+      padding: 32px 24px;
       text-align: center;
+    }
+    .header-brand {
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 13px;
+      font-weight: 400;
+      color: #8FBD9E;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 10px;
     }
     .header h1 {
       margin: 0;
-      font-size: 24px;
-      font-weight: 600;
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 26px;
+      font-weight: 700;
+      color: #F5F0E8;
+      letter-spacing: -0.01em;
     }
     .content {
-      padding: 20px;
+      padding: 24px 24px 8px;
+      background: #F5F0E8;
     }
     .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
+      margin: 16px 0;
+      padding: 16px;
+      background: #FDF8F0;
+      border-left: 4px solid #D4622A;
+      border-radius: 6px;
     }
     .section-title {
-      font-size: 14px;
+      font-size: 10px;
       font-weight: 600;
-      color: #57534e;
+      color: #7A7468;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.16em;
       margin: 0 0 12px 0;
     }
     .field {
-      margin-bottom: 12px;
+      margin-bottom: 10px;
+      font-size: 13px;
     }
     .label {
       font-weight: 600;
-      color: #57534e;
-      margin-right: 8px;
+      color: #7A7468;
+      margin-right: 6px;
     }
     .value {
-      color: #1c1917;
+      color: #1A1A14;
     }
     .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
+      margin-top: 0;
+      padding: 20px 24px;
+      background: #1E3A2F;
       font-size: 12px;
-      color: #78716c;
+      color: #8FBD9E;
+    }
+    .footer strong {
+      color: #C5DFC9;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>✉️ Event Submission Received</h1>
+    <div class="header-brand">Nyack Today</div>
+    <h1>Submission Received</h1>
   </div>
 
   <div class="content">
@@ -533,36 +561,36 @@ function generateConfirmationHtmlEmail(submission: EventSubmission): string {
       </div>
 
       <div class="field">
-        <span class="label">${submission.isRecurring ? '📅 Schedule:' : '📅 Date:'}</span>
+        <span class="label">${submission.isRecurring ? 'Schedule:' : 'Date:'}</span>
         <span class="value">${dateDisplay}</span>
       </div>
 
       <div class="field">
-        <span class="label">🕐 Time:</span>
+        <span class="label">Time:</span>
         <span class="value">${timeDisplay}</span>
       </div>
 
       <div class="field">
-        <span class="label">📍 Venue:</span>
+        <span class="label">Venue:</span>
         <span class="value">${escapeHtml(submission.venue)}</span>
       </div>
     </div>
 
     <div class="section">
       <div class="section-title">What Happens Next</div>
-      <ul style="margin: 0; padding-left: 20px;">
-        <li>Our team will review your submission within 24-48 hours</li>
-        <li>We'll send you an email when your event is approved or if we need more information</li>
+      <ul style="margin: 0; padding-left: 20px; font-size: 13px; color: #1A1A14;">
+        <li style="margin-bottom: 6px;">Our team will review your submission within 24–48 hours</li>
+        <li style="margin-bottom: 6px;">We'll send you an email when your event is approved or if we need more information</li>
         <li>Once approved, your event will be live on Nyack Today for the community to discover</li>
       </ul>
     </div>
 
-    <p>Questions? Reply to this email or contact us at submissions@nyacktoday.com</p>
+    <p style="font-size: 13px; color: #7A7468; margin-bottom: 32px;">Questions? Reply to this email or contact us at <a href="mailto:submissions@nyacktoday.com" style="color: #D4622A;">submissions@nyacktoday.com</a></p>
   </div>
 
   <div class="footer">
     <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Submitted:</strong> ${submittedAt}</div>
+    <div style="margin-top: 4px;"><strong>Submitted:</strong> ${submittedAt}</div>
   </div>
 </body>
 </html>
@@ -580,7 +608,6 @@ function generateConfirmationPlainTextEmail(
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -639,7 +666,6 @@ Submitted: ${submittedAt}
 export async function sendSubmissionConfirmationEmail(
   submission: EventSubmission
 ): Promise<void> {
-  // Validate environment variables
   const apiKey = process.env.RESEND_API_KEY
 
   if (!apiKey) {
@@ -665,7 +691,6 @@ export async function sendSubmissionConfirmationEmail(
 
     console.log(`Confirmation email sent to: ${submission.submitterEmail}`)
   } catch (error) {
-    // Log error but don't throw - email is not critical to submission success
     console.error('Failed to send confirmation email:', error)
   }
 }
@@ -682,7 +707,6 @@ function generateApprovalHtmlEmail(
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -705,7 +729,7 @@ function generateApprovalHtmlEmail(
 
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
   const eventUrl = submission.isRecurring
-    ? siteUrl // For recurring events, link to homepage
+    ? siteUrl
     : `${siteUrl}/events/${event.id}`
 
   return `
@@ -718,73 +742,90 @@ function generateApprovalHtmlEmail(
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
       line-height: 1.6;
-      color: #333;
+      color: #1A1A14;
       max-width: 600px;
       margin: 0 auto;
       padding: 0;
+      background-color: #F5F0E8;
     }
     .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
+      background-color: #1E3A2F;
+      padding: 32px 24px;
       text-align: center;
+    }
+    .header-brand {
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 13px;
+      font-weight: 400;
+      color: #8FBD9E;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 10px;
     }
     .header h1 {
       margin: 0;
-      font-size: 24px;
-      font-weight: 600;
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 26px;
+      font-weight: 700;
+      color: #F5F0E8;
+      letter-spacing: -0.01em;
     }
     .content {
-      padding: 20px;
+      padding: 24px 24px 8px;
+      background: #F5F0E8;
     }
     .event-title {
-      font-size: 22px;
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 20px;
       font-weight: 700;
-      color: #1c1917;
-      margin: 20px 0;
+      color: #1A1A14;
+      margin: 16px 0;
+      letter-spacing: -0.01em;
     }
     .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
+      margin: 16px 0;
+      padding: 16px;
+      background: #FDF8F0;
+      border-left: 4px solid #D4622A;
+      border-radius: 6px;
+      font-size: 13px;
+      color: #1A1A14;
     }
     .section-title {
-      font-size: 14px;
+      font-size: 10px;
       font-weight: 600;
-      color: #57534e;
+      color: #7A7468;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.16em;
       margin: 0 0 12px 0;
     }
     .cta-button {
       display: inline-block;
-      margin: 30px 0;
-      padding: 14px 28px;
-      background: #f97316;
-      color: white !important;
+      margin: 24px 0;
+      padding: 13px 28px;
+      background: #D4622A;
+      color: #FEF0E6 !important;
       text-decoration: none;
-      border-radius: 8px;
+      border-radius: 20px;
       font-weight: 600;
-      font-size: 16px;
-    }
-    .cta-button:hover {
-      background: #ea580c;
+      font-size: 14px;
     }
     .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
+      margin-top: 0;
+      padding: 20px 24px;
+      background: #1E3A2F;
       font-size: 12px;
-      color: #78716c;
+      color: #8FBD9E;
+    }
+    .footer strong {
+      color: #C5DFC9;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>🎉 Your Event is Live!</h1>
+    <div class="header-brand">Nyack Today</div>
+    <h1>Your Event is Live!</h1>
   </div>
 
   <div class="content">
@@ -794,26 +835,26 @@ function generateApprovalHtmlEmail(
 
     <div class="section">
       <div>${dateDisplay}</div>
-      <div style="margin-top: 8px;">📍 ${escapeHtml(submission.venue)}</div>
+      <div style="margin-top: 8px; color: #7A7468;">&#128205; ${escapeHtml(submission.venue)}</div>
     </div>
 
     <div style="text-align: center;">
       <a href="${eventUrl}" class="cta-button">
-        ${submission.isRecurring ? 'View Nyack Today' : 'View Your Event on Nyack Today'}
+        ${submission.isRecurring ? 'Visit Nyack Today' : 'View Your Event'}
       </a>
     </div>
 
     <div class="section">
       <div class="section-title">Share Your Event</div>
-      <p style="margin: 0;">Help spread the word! Share the link above with friends, family, and on social media.</p>
+      <p style="margin: 0; font-size: 13px;">Help spread the word! Share the link above with friends, family, and on social media.</p>
     </div>
 
-    <p>Thank you for contributing to the Nyack community! We appreciate you helping locals discover great things to do.</p>
+    <p style="font-size: 13px; color: #7A7468; margin-bottom: 32px;">Thank you for contributing to the Nyack community! We appreciate you helping locals discover great things to do.</p>
   </div>
 
   <div class="footer">
     <div><strong>Event ID:</strong> ${event.id}</div>
-    <div><strong>Approved:</strong> ${approvedAt}</div>
+    <div style="margin-top: 4px;"><strong>Approved:</strong> ${approvedAt}</div>
   </div>
 </body>
 </html>
@@ -832,7 +873,6 @@ function generateApprovalPlainTextEmail(
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -868,7 +908,7 @@ ${submission.title}
 ${dateDisplay}
 ${submission.venue}
 
-${submission.isRecurring ? 'VIEW NYACK TODAY' : 'VIEW YOUR EVENT'}
+${submission.isRecurring ? 'VISIT NYACK TODAY' : 'VIEW YOUR EVENT'}
 ${eventUrl}
 
 SHARE YOUR EVENT
@@ -884,13 +924,11 @@ Approved: ${approvedAt}
 
 /**
  * Send approval email to submitter when event is approved
- * Includes link to live event on the site
  */
 export async function sendSubmissionApprovalEmail(
   submission: EventSubmission,
   event: Event
 ): Promise<void> {
-  // Validate environment variables
   const apiKey = process.env.RESEND_API_KEY
 
   if (!apiKey) {
@@ -914,7 +952,6 @@ export async function sendSubmissionApprovalEmail(
 
     console.log(`Approval email sent to: ${submission.submitterEmail}`)
   } catch (error) {
-    // Log error but don't throw - email is not critical
     console.error('Failed to send approval email:', error)
   }
 }
@@ -928,7 +965,6 @@ function generateRejectionHtmlEmail(submission: EventSubmission): string {
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -958,60 +994,82 @@ function generateRejectionHtmlEmail(submission: EventSubmission): string {
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
       line-height: 1.6;
-      color: #333;
+      color: #1A1A14;
       max-width: 600px;
       margin: 0 auto;
       padding: 0;
+      background-color: #F5F0E8;
     }
     .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
+      background-color: #1E3A2F;
+      padding: 32px 24px;
       text-align: center;
+    }
+    .header-brand {
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 13px;
+      font-weight: 400;
+      color: #8FBD9E;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      margin-bottom: 10px;
     }
     .header h1 {
       margin: 0;
-      font-size: 24px;
-      font-weight: 600;
+      font-family: Georgia, 'Times New Roman', serif;
+      font-size: 26px;
+      font-weight: 700;
+      color: #F5F0E8;
+      letter-spacing: -0.01em;
     }
     .content {
-      padding: 20px;
+      padding: 24px 24px 8px;
+      background: #F5F0E8;
     }
     .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
+      margin: 16px 0;
+      padding: 16px;
+      background: #FDF8F0;
+      border-left: 4px solid #D4622A;
+      border-radius: 6px;
+      font-size: 13px;
     }
     .section-title {
-      font-size: 14px;
+      font-size: 10px;
       font-weight: 600;
-      color: #57534e;
+      color: #7A7468;
       text-transform: uppercase;
-      letter-spacing: 0.5px;
+      letter-spacing: 0.16em;
       margin: 0 0 12px 0;
     }
     .reason-box {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fff7ed;
-      border-left: 4px solid #ea580c;
-      border-radius: 4px;
+      margin: 16px 0;
+      padding: 16px;
+      background: #FDF3E3;
+      border-left: 4px solid #C8973A;
+      border-radius: 6px;
+      font-size: 13px;
     }
     .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
+      margin-top: 0;
+      padding: 20px 24px;
+      background: #1E3A2F;
       font-size: 12px;
-      color: #78716c;
+      color: #8FBD9E;
+    }
+    .footer strong {
+      color: #C5DFC9;
+    }
+    a {
+      color: #D4622A;
+      text-decoration: underline;
     }
   </style>
 </head>
 <body>
   <div class="header">
-    <h1>📬 Event Submission Update</h1>
+    <div class="header-brand">Nyack Today</div>
+    <h1>Submission Update</h1>
   </div>
 
   <div class="content">
@@ -1031,22 +1089,22 @@ function generateRejectionHtmlEmail(submission: EventSubmission): string {
         ? `
     <div class="reason-box">
       <div class="section-title">Review Notes</div>
-      <p style="margin: 0;">${escapeHtml(submission.rejectionReason)}</p>
+      <p style="margin: 0; color: #1A1A14;">${escapeHtml(submission.rejectionReason)}</p>
     </div>
     `
         : ''
     }
 
-    <p>This may be because the event falls outside our geographic focus (Nyack and immediate surrounding areas), doesn't fit our event categories, or we need more information to verify the details.</p>
+    <p style="font-size: 13px;">This may be because the event falls outside our geographic focus (Nyack and immediate surrounding areas), doesn't fit our event categories, or we need more information to verify the details.</p>
 
-    <p><strong>Please don't let this discourage you!</strong> We'd love to see future events you're hosting. You can submit another event anytime at ${siteUrl}/submit</p>
+    <p style="font-size: 13px;"><strong>Please don't let this discourage you!</strong> We'd love to see future events you're hosting. You can submit another event anytime at <a href="${siteUrl}/submit">${siteUrl}/submit</a></p>
 
-    <p>If you have questions or want to discuss this submission, feel free to reply to this email.</p>
+    <p style="font-size: 13px; color: #7A7468; margin-bottom: 32px;">If you have questions or want to discuss this submission, feel free to reply to this email.</p>
   </div>
 
   <div class="footer">
     <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Reviewed:</strong> ${reviewedAt}</div>
+    <div style="margin-top: 4px;"><strong>Reviewed:</strong> ${reviewedAt}</div>
   </div>
 </body>
 </html>
@@ -1062,7 +1120,6 @@ function generateRejectionPlainTextEmail(submission: EventSubmission): string {
     timeStyle: 'short',
   })
 
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
     const recurrence = formatRecurrencePattern(
@@ -1128,31 +1185,37 @@ function generateWelcomeHtmlEmail(unsubscribeUrl: string): string {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 0; }
-    .header { background-color: #f97316; color: white; padding: 30px 20px; text-align: center; }
-    .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-    .content { padding: 24px 20px; }
-    .section { margin: 20px 0; padding: 15px; background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; }
-    .cta-button { display: inline-block; margin: 20px 0; padding: 12px 24px; background: #f97316; color: white !important; text-decoration: none; border-radius: 8px; font-weight: 600; }
-    .footer { margin-top: 30px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; }
-    a { color: #f97316; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1A1A14; max-width: 600px; margin: 0 auto; padding: 0; background-color: #F5F0E8; }
+    .header { background-color: #1E3A2F; padding: 32px 24px; text-align: center; }
+    .header-brand { font-family: Georgia, 'Times New Roman', serif; font-size: 13px; font-weight: 400; color: #8FBD9E; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px; }
+    .header h1 { margin: 0; font-family: Georgia, 'Times New Roman', serif; font-size: 26px; font-weight: 700; color: #F5F0E8; letter-spacing: -0.01em; }
+    .content { padding: 24px 24px 8px; background: #F5F0E8; }
+    .section { margin: 16px 0; padding: 16px; background: #FDF8F0; border-left: 4px solid #D4622A; border-radius: 6px; font-size: 13px; color: #1A1A14; }
+    .cta-button { display: inline-block; margin: 20px 0; padding: 12px 24px; background: #D4622A; color: #FEF0E6 !important; text-decoration: none; border-radius: 20px; font-weight: 600; font-size: 13px; }
+    .footer { margin-top: 0; padding: 20px 24px; background: #1E3A2F; font-size: 12px; color: #8FBD9E; }
+    .footer a { color: #C5DFC9; text-decoration: none; }
+    a { color: #D4622A; }
   </style>
 </head>
 <body>
-  <div class="header"><h1>You're in! 🎉</h1></div>
+  <div class="header">
+    <div class="header-brand">Nyack Today</div>
+    <h1>You're in!</h1>
+  </div>
   <div class="content">
     <p>Thanks for subscribing to the <strong>Nyack Today weekly digest</strong>.</p>
     <div class="section">
       Every <strong>Thursday morning</strong> you'll get a quick roundup of what's happening in Nyack and the surrounding area — this weekend and beyond.
     </div>
-    <p>In the meantime, check out what's happening right now:</p>
+    <p style="font-size: 13px;">In the meantime, check out what's happening right now:</p>
     <div style="text-align: center;">
       <a href="${siteUrl}" class="cta-button">Browse Events</a>
     </div>
+    <p style="font-size: 11px; color: #7A7468; margin-top: 32px; margin-bottom: 0;">&nbsp;</p>
   </div>
   <div class="footer">
     <div>Nyack Today &middot; <a href="${siteUrl}">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
-    <div style="margin-top: 8px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
+    <div style="margin-top: 8px;"><a href="${unsubscribeUrl}">Unsubscribe</a></div>
   </div>
 </body>
 </html>`.trim()
@@ -1217,16 +1280,16 @@ export function generateDigestHtml(
     })
 
   const eventRows = events.length === 0
-    ? `<p style="color: #57534e; font-style: italic;">No events found this week — check back next Thursday!</p>`
+    ? `<p style="color: #7A7468; font-style: italic; font-size: 13px;">No events found this week — check back next Thursday!</p>`
     : events.map((e, i) => `
-      ${i > 0 ? '<hr style="border: none; border-top: 1px solid #e7e5e4; margin: 12px 0;">' : ''}
+      ${i > 0 ? '<hr style="border: none; border-top: 1px solid #DDD6C6; margin: 14px 0;">' : ''}
       <div style="padding: 4px 0;">
         <div style="margin-bottom: 4px;">
-          <a href="${escapeHtml(e.sourceUrl)}" style="color: #f97316; font-weight: 600; text-decoration: underline; font-size: 16px;">${escapeHtml(e.title)}</a>
-          ${e.isFree ? '<span style="margin-left: 8px; background: #dcfce7; color: #166534; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; display: inline-block;">FREE</span>' : ''}
+          <a href="${escapeHtml(e.sourceUrl)}" style="color: #D4622A; font-weight: 600; text-decoration: underline; font-size: 15px;">${escapeHtml(e.title)}</a>
+          ${e.isFree ? '<span style="margin-left: 8px; background: rgba(143,189,158,0.2); color: #2C5240; font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; display: inline-block; letter-spacing: 0.08em; text-transform: uppercase;">Free</span>' : ''}
         </div>
-        <div style="color: #57534e; font-size: 14px;">${formatEventDate(e.startDate)}</div>
-        <div style="color: #78716c; font-size: 14px;">${escapeHtml(e.venue)}</div>
+        <div style="color: #7A7468; font-size: 13px;">${formatEventDate(e.startDate)}</div>
+        <div style="color: #7A7468; font-size: 13px;">${escapeHtml(e.venue)}</div>
       </div>`).join('')
 
   return `
@@ -1236,34 +1299,35 @@ export function generateDigestHtml(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1c1917; max-width: 600px; margin: 0 auto; padding: 0; }
-    a { color: #f97316; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1A1A14; max-width: 600px; margin: 0 auto; padding: 0; background-color: #F5F0E8; }
+    a { color: #D4622A; }
   </style>
 </head>
 <body>
-  <div style="background-color: #f97316; color: white; padding: 30px 20px; text-align: center;">
-    <div style="font-size: 13px; font-weight: 500; opacity: 0.85; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 1px;">Nyack Today</div>
-    <h1 style="margin: 0; font-size: 26px; font-weight: 700;">Nyack This Week</h1>
-    <div style="font-size: 15px; margin-top: 6px; opacity: 0.9;">${escapeHtml(weekLabel)}</div>
+  <div style="background-color: #1E3A2F; padding: 32px 24px; text-align: center;">
+    <div style="font-family: Georgia, 'Times New Roman', serif; font-size: 13px; font-weight: 400; color: #8FBD9E; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 10px;">Nyack Today</div>
+    <h1 style="margin: 0; font-family: Georgia, 'Times New Roman', serif; font-size: 28px; font-weight: 700; color: #F5F0E8; letter-spacing: -0.02em;">Nyack This Week</h1>
+    <div style="font-size: 14px; margin-top: 8px; color: #8FBD9E;">${escapeHtml(weekLabel)}</div>
   </div>
 
-  <div style="padding: 24px 20px;">
-    <div style="background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; padding: 16px; margin-bottom: 24px; color: #44403c; font-size: 15px; line-height: 1.7;">
+  <div style="padding: 24px 24px 8px; background: #F5F0E8;">
+    <div style="background: #FDF8F0; border-left: 4px solid #D4622A; border-radius: 6px; padding: 16px; margin-bottom: 24px; color: #1A1A14; font-size: 14px; line-height: 1.7;">
       ${escapeHtml(aiSummary)}
     </div>
 
-    <h2 style="font-size: 18px; font-weight: 700; color: #1c1917; margin: 0 0 16px 0;">Upcoming Events</h2>
+    <h2 style="font-family: Georgia, 'Times New Roman', serif; font-size: 18px; font-weight: 700; color: #1A1A14; margin: 0 0 16px 0; letter-spacing: -0.01em;">Upcoming Events</h2>
     ${eventRows}
 
-    <div style="text-align: center; margin-top: 28px;">
-      <a href="${siteUrl}" style="display: inline-block; padding: 12px 28px; background: #f97316; color: white; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px;">See All Events</a>
+    <div style="text-align: center; margin-top: 28px; margin-bottom: 32px;">
+      <a href="${siteUrl}" style="display: inline-block; padding: 13px 28px; background: #D4622A; color: #FEF0E6; text-decoration: none; border-radius: 20px; font-weight: 600; font-size: 14px;">See All Events</a>
     </div>
   </div>
 
-  <div style="margin-top: 20px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; text-align: center;">
-    <div><strong>Nyack Today</strong> &middot; <a href="${siteUrl}" style="color: #78716c;">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
+  <div style="padding: 20px 24px; background: #1E3A2F; font-size: 12px; color: #8FBD9E; text-align: center;">
+    <div style="font-family: Georgia, 'Times New Roman', serif; font-size: 14px; color: #C5DFC9; margin-bottom: 8px;">Nyack Today</div>
+    <div><a href="${siteUrl}" style="color: #8FBD9E; text-decoration: none;">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
     <div style="margin-top: 6px;">You're receiving this because you subscribed at Nyack Today.</div>
-    <div style="margin-top: 6px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
+    <div style="margin-top: 6px;"><a href="${unsubscribeUrl}" style="color: #8FBD9E; text-decoration: none;">Unsubscribe</a></div>
   </div>
 </body>
 </html>`.trim()
@@ -1308,12 +1372,10 @@ Unsubscribe: ${unsubscribeUrl}
 
 /**
  * Send rejection email to submitter when event is rejected
- * Includes optional reason from admin
  */
 export async function sendSubmissionRejectionEmail(
   submission: EventSubmission
 ): Promise<void> {
-  // Validate environment variables
   const apiKey = process.env.RESEND_API_KEY
 
   if (!apiKey) {
@@ -1337,7 +1399,6 @@ export async function sendSubmissionRejectionEmail(
 
     console.log(`Rejection email sent to: ${submission.submitterEmail}`)
   } catch (error) {
-    // Log error but don't throw - email is not critical
     console.error('Failed to send rejection email:', error)
   }
 }


### PR DESCRIPTION
## Summary

- **New design system**: replaces the orange (`#f97316`) palette with a warm editorial look — forest green (`#1E3A2F`), terra (`#D4622A`), oat (`#F5F0E8`), and serif display typography (Fraunces + Plus Jakarta Sans)
- **All pages restyled**: Home, Activities, Submit — new Hero sections, card layouts, chip filters, and a full Footer component
- **Email templates updated**: all 6 HTML emails (admin notification, submission confirmation, approval, rejection, welcome, weekly digest) now use the new palette, Georgia serif headings, pill buttons, and forest green headers/footers
- **New components**: `CatIcon` (SVG category icons), `Footer` (forest green with nav columns)
- **Simplified filter state**: `quickFilter` string replaces the old complex `Filters` object; mapped to API params via `QUICK_FILTER_MAP`

## Key files changed

| Area | Files |
|------|-------|
| Design tokens | `globals.css`, `layout.tsx`, `categories.ts` |
| Navigation | `Header.tsx`, `BottomNav.tsx`, `Footer.tsx` |
| Home page | `page.tsx`, `Hero.tsx`, `MarqueeSection.tsx`, `EventCard.tsx`, `EventList.tsx`, `EventCardSkeleton.tsx`, `SubscribeSection.tsx` |
| Activities | `activities/page.tsx`, `ActivityCard.tsx`, `CatIcon.tsx` |
| Submit | `submit/page.tsx` |
| Emails | `email.ts` |

## Test plan

- [ ] Home page: date chips, category chips, event list, marquee cards all render correctly
- [ ] Activities page: filter chips, activity cards, hike promo block
- [ ] Submit page: form, success state, green hero
- [ ] Footer links work (Today's events, Always-on, Submit, Newsletter anchor, Contact)
- [ ] Email templates: verify HTML renders correctly in an email client (forest header, oat body, terra accents, pill CTA buttons)
- [ ] Mobile: bottom nav, responsive layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)