### PR TITLE
feat: apply new Hudson Valley design system

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -70,16 +70,16 @@ export default function ActivitiesPage() {
   }
 
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
 
       <main className="max-w-4xl mx-auto px-4 py-6">
         {/* Header section */}
         <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">
+          <h1 className="font-display font-semibold text-3xl text-ink mb-2">
             Always Available
           </h1>
-          <p className="text-stone-600">
+          <p className="text-muted text-sm">
             Things to do anytime in Nyack and the surrounding area
           </p>
         </div>
@@ -90,7 +90,7 @@ export default function ActivitiesPage() {
           <select
             value={filters.category}
             onChange={(e) => updateFilter('category', e.target.value as Category | 'ALL')}
-            className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+            className="px-3 py-2 rounded-lg border border-sand bg-surface text-sm text-ink focus:outline-none focus:ring-2 focus:ring-terra"
           >
             <option value="ALL">All Categories</option>
             {Object.entries(categoryLabels).map(([value, label]) => (
@@ -104,7 +104,7 @@ export default function ActivitiesPage() {
           <select
             value={filters.priceFilter}
             onChange={(e) => updateFilter('priceFilter', e.target.value as ActivityFilters['priceFilter'])}
-            className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+            className="px-3 py-2 rounded-lg border border-sand bg-surface text-sm text-ink focus:outline-none focus:ring-2 focus:ring-terra"
           >
             <option value="all">Any Price</option>
             <option value="free">Free Only</option>
@@ -119,7 +119,7 @@ export default function ActivitiesPage() {
               ${
                 filters.familyFriendly
                   ? 'bg-green-100 text-green-700 border border-green-300'
-                  : 'bg-white text-stone-600 border border-stone-200 hover:bg-stone-50'
+                  : 'bg-surface text-stone-600 border border-sand hover:bg-oat'
               }
             `}
           >
@@ -130,12 +130,12 @@ export default function ActivitiesPage() {
         {/* Activities list */}
         {loading ? (
           <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-orange-500 mx-auto"></div>
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-terra mx-auto"></div>
           </div>
         ) : filteredActivities.length === 0 ? (
           <div className="text-center py-12">
             <div className="text-4xl mb-4">🎯</div>
-            <p className="text-stone-500">No activities found</p>
+            <p className="text-muted">No activities found</p>
             <p className="text-sm text-stone-400 mt-2">
               {activities.length === 0
                 ? 'No activities have been added yet'

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,75 +1,55 @@
 @import "tailwindcss";
 
 :root {
-  /* Sunset Orange Palette */
-  --primary-50: #fff7ed;
-  --primary-100: #ffedd5;
-  --primary-200: #fed7aa;
-  --primary-300: #fdba74;
-  --primary-400: #fb923c;
-  --primary-500: #f97316;
-  --primary-600: #ea580c;
-  --primary-700: #c2410c;
-  --primary-800: #9a3412;
-  --primary-900: #7c2d12;
-
-  /* Golden Hour */
-  --secondary-500: #eab308;
-
-  /* River Blue (accent) */
-  --accent-500: #0ea5e9;
-
-  /* Neutrals - warm stone */
-  --background: #fafaf9;
-  --foreground: #1c1917;
-  --muted: #78716c;
+  --background: #ECE4D2;
+  --foreground: #1A1A14;
+  --muted: #7A7468;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --color-primary: var(--primary-500);
-  --color-primary-dark: var(--primary-600);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+
+  /* Design system palette */
+  --color-forest:  #1E3A2F;
+  --color-deep:    #2C5240;
+  --color-terra:   #D4622A;
+  --color-harvest: #C8973A;
+  --color-oat:     #F5F0E8;
+  --color-surface: #FDF8F0;
+  --color-ink:     #1A1A14;
+  --color-muted:   #7A7468;
+  --color-sand:    #DDD6C6;
+  --color-sage:    #8FBD9E;
+  --color-cream:   #FEF0E6;
+
+  /* Fonts */
+  --font-sans: var(--font-jakarta);
+  --font-display: var(--font-fraunces);
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
-}
-
-/* Custom utility classes */
-.text-primary {
-  color: var(--primary-500);
-}
-
-.bg-primary {
-  background-color: var(--primary-500);
-}
-
-.bg-primary-dark {
-  background-color: var(--primary-600);
-}
-
-.text-muted {
-  color: var(--muted);
+  font-family: var(--font-sans), system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 /* react-day-picker custom theme */
 .rdp-custom {
-  --rdp-accent-color: #f97316;
-  --rdp-accent-background-color: #fff7ed;
-  --rdp-selected-border: 2px solid #f97316;
+  --rdp-accent-color: #D4622A;
+  --rdp-accent-background-color: #FEF0E6;
+  --rdp-selected-border: 2px solid #D4622A;
 }
 
 .rdp-custom .rdp-day_button:hover:not([disabled]) {
-  background-color: #fff7ed;
+  background-color: #FEF0E6;
 }
 
 .rdp-custom .rdp-selected .rdp-day_button {
-  background-color: #f97316;
+  background-color: #D4622A;
   color: white;
   font-weight: 600;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,18 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Plus_Jakarta_Sans, Fraunces } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const plusJakartaSans = Plus_Jakarta_Sans({
+  variable: "--font-jakarta",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const fraunces = Fraunces({
+  variable: "--font-fraunces",
   subsets: ["latin"],
+  weight: ["500", "600", "700"],
 });
 
 const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://nyacktoday.com';
@@ -69,7 +71,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  themeColor: "#f97316",
+  themeColor: "#1E3A2F",
 };
 
 export default function RootLayout({
@@ -80,7 +82,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-stone-50 min-h-screen`}
+        className={`${plusJakartaSans.variable} ${fraunces.variable} antialiased min-h-screen`}
       >
         {children}
         <Analytics />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -223,7 +223,7 @@ export default function Home() {
   const showDate = !!customDate || (dateFilter !== 'tonight' && dateFilter !== 'tomorrow')
 
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
       <Hero />
 
@@ -231,10 +231,10 @@ export default function Home() {
         <MarqueeSection onShowAll={handleShowAllMarquee} />
 
         <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">
+          <h1 className="font-display font-semibold text-3xl text-ink mb-2">
             {getHeading()}
           </h1>
-          <p className="text-stone-600">
+          <p className="text-muted text-sm">
             Discover events and activities in Nyack and the surrounding area
           </p>
         </div>
@@ -254,11 +254,11 @@ export default function Home() {
         </div>
 
         {marqueeOnly && (
-          <div className="mb-4 bg-amber-50 border border-amber-200 rounded-xl px-4 py-2.5 flex items-center justify-between">
-            <span className="text-sm text-amber-800 font-medium">Showing all upcoming marquee events</span>
+          <div className="mb-4 bg-cream border border-harvest/30 rounded-xl px-4 py-2.5 flex items-center justify-between">
+            <span className="text-sm text-harvest font-medium">Showing all upcoming marquee events</span>
             <button
               onClick={handleClearMarquee}
-              className="text-amber-600 hover:text-amber-900 text-sm font-medium"
+              className="text-terra hover:text-terra/70 text-sm font-medium"
             >
               ✕ Clear
             </button>
@@ -274,7 +274,7 @@ export default function Home() {
             <p className="text-red-500 mb-4">{error}</p>
             <button
               onClick={fetchEvents}
-              className="px-4 py-2 bg-orange-500 text-white rounded-lg hover:bg-orange-600 transition-colors"
+              className="px-4 py-2 bg-terra text-cream rounded-lg hover:bg-terra/90 transition-colors"
             >
               Try Again
             </button>

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -313,23 +313,23 @@ export default function SubmitEventPage() {
   // Success state - show confirmation
   if (success) {
     return (
-      <div className="min-h-screen bg-stone-50">
+      <div className="min-h-screen">
         <Header />
         <main className="max-w-2xl mx-auto px-4 py-12">
-          <div className="bg-white rounded-xl shadow-lg p-8 text-center">
+          <div className="bg-surface rounded-xl shadow-lg p-8 text-center">
             <div className="w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
               <svg className="w-8 h-8 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
               </svg>
             </div>
-            <h1 className="text-2xl font-bold text-stone-900 mb-2">Event Submitted!</h1>
-            <p className="text-stone-600 mb-6">
+            <h1 className="text-2xl font-bold text-ink mb-2">Event Submitted!</h1>
+            <p className="text-muted mb-6">
               Thank you for submitting your event. Our team will review it and it should appear on the site within 24-48 hours.
             </p>
             <div className="flex gap-4 justify-center">
               <Link
                 href="/"
-                className="px-6 py-2 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 transition-colors"
+                className="px-6 py-2 bg-terra text-white rounded-lg font-medium hover:bg-terra/90 transition-colors"
               >
                 View Events
               </Link>
@@ -377,29 +377,29 @@ export default function SubmitEventPage() {
 
   // Form state - render form
   return (
-    <div className="min-h-screen bg-stone-50">
+    <div className="min-h-screen">
       <Header />
 
       <main className="max-w-2xl mx-auto px-4 py-8">
         <div className="mb-6">
-          <h1 className="text-3xl font-bold text-stone-900 mb-2">Submit an Event</h1>
+          <h1 className="text-3xl font-bold text-ink mb-2">Submit an Event</h1>
           <p className="text-stone-600">
             Know about an upcoming event in Nyack? Share it with the community!
             We&apos;ll review your submission and add it to the calendar.
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="bg-white rounded-xl shadow-lg p-6 space-y-6">
+        <form onSubmit={handleSubmit} className="bg-surface rounded-xl shadow-lg p-6 space-y-6">
           {/* Poster Scan Section */}
-          <div className="bg-orange-50 border-2 border-orange-200 rounded-xl p-4">
+          <div className="bg-cream border-2 border-harvest/30 rounded-xl p-4">
             <div className="flex items-center gap-2 mb-2">
-              <svg className="w-5 h-5 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <svg className="w-5 h-5 text-terra" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              <h2 className="font-semibold text-orange-800">See a poster? Snap it to auto-fill!</h2>
+              <h2 className="font-semibold text-harvest">See a poster? Snap it to auto-fill!</h2>
             </div>
-            <p className="text-sm text-orange-700 mb-3">
+            <p className="text-sm text-harvest mb-3">
               Take a photo of an event poster and we&apos;ll fill in the details for you automatically.
             </p>
 
@@ -422,7 +422,7 @@ export default function SubmitEventPage() {
               <button
                 type="button"
                 onClick={() => posterInputRef.current?.click()}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 active:bg-orange-700 transition-colors"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-terra text-white rounded-lg font-medium hover:bg-terra/90 active:bg-terra/80 transition-colors"
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
@@ -437,10 +437,10 @@ export default function SubmitEventPage() {
               <div className="space-y-3">
                 {posterPreview && (
                   <div className="relative">
-                    <img src={posterPreview} alt="Poster preview" className="w-full max-h-48 object-contain rounded-lg border border-orange-200" />
-                    <div className="absolute inset-0 bg-orange-900/40 rounded-lg flex items-center justify-center">
+                    <img src={posterPreview} alt="Poster preview" className="w-full max-h-48 object-contain rounded-lg border border-harvest/30" />
+                    <div className="absolute inset-0 bg-forest/60 rounded-lg flex items-center justify-center">
                       <div className="bg-white rounded-lg px-4 py-2 flex items-center gap-2">
-                        <svg className="animate-spin h-4 w-4 text-orange-500" viewBox="0 0 24 24">
+                        <svg className="animate-spin h-4 w-4 text-terra" viewBox="0 0 24 24">
                           <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                           <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
                         </svg>
@@ -455,7 +455,7 @@ export default function SubmitEventPage() {
             {/* Success state */}
             {posterFilled && posterPreview && !scanningPoster && (
               <div className="space-y-3">
-                <img src={posterPreview} alt="Scanned poster" className="w-full max-h-48 object-contain rounded-lg border border-orange-200" />
+                <img src={posterPreview} alt="Scanned poster" className="w-full max-h-48 object-contain rounded-lg border border-harvest/30" />
                 <div className="flex items-center gap-2 text-green-700 bg-green-50 rounded-lg px-3 py-2">
                   <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
@@ -471,7 +471,7 @@ export default function SubmitEventPage() {
                     setPreviewUrl('')
                     posterInputRef.current?.click()
                   }}
-                  className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                  className="text-sm text-terra hover:text-harvest font-medium"
                 >
                   Scan a different poster
                 </button>
@@ -487,7 +487,7 @@ export default function SubmitEventPage() {
                 <button
                   type="button"
                   onClick={() => posterInputRef.current?.click()}
-                  className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                  className="text-sm text-terra hover:text-harvest font-medium"
                 >
                   Try again
                 </button>
@@ -503,11 +503,11 @@ export default function SubmitEventPage() {
 
           {/* Required Fields Section */}
           <div className="border-b border-stone-200 pb-4">
-            <h2 className="font-semibold text-stone-900 mb-4">Required Information</h2>
+            <h2 className="font-semibold text-ink mb-4">Required Information</h2>
 
             {/* Title */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Event Title *
               </label>
               <input
@@ -516,7 +516,7 @@ export default function SubmitEventPage() {
                 value={formData.title}
                 onChange={(e) => updateField('title', e.target.value)}
                 placeholder="e.g., Live Jazz at The Turning Point"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               />
             </div>
 
@@ -525,7 +525,7 @@ export default function SubmitEventPage() {
               {/* Only show Event Date for one-time events */}
               {!formData.isRecurring && (
                 <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
+                  <label className="block text-sm font-medium text-ink mb-1">
                     Event Date *
                   </label>
                   <input
@@ -533,12 +533,12 @@ export default function SubmitEventPage() {
                     required
                     value={formData.startDate}
                     onChange={(e) => updateField('startDate', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                   />
                 </div>
               )}
               <div className={formData.isRecurring ? 'col-span-2' : ''}>
-                <label className="block text-sm font-medium text-stone-700 mb-1">
+                <label className="block text-sm font-medium text-ink mb-1">
                   Start Time *
                 </label>
                 <input
@@ -546,7 +546,7 @@ export default function SubmitEventPage() {
                   required
                   value={formData.startTime}
                   onChange={(e) => updateField('startTime', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                 />
               </div>
             </div>
@@ -617,14 +617,14 @@ export default function SubmitEventPage() {
 
                   {/* Recurrence End Date */}
                   <div>
-                    <label className="block text-sm font-medium text-stone-700 mb-1">
+                    <label className="block text-sm font-medium text-ink mb-1">
                       Ends on (optional)
                     </label>
                     <input
                       type="date"
                       value={formData.recurrenceEndDate}
                       onChange={(e) => updateField('recurrenceEndDate', e.target.value)}
-                      className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
+                      className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-purple-500"
                     />
                     <p className="text-xs text-stone-500 mt-1">
                       Leave blank if this event continues indefinitely
@@ -636,7 +636,7 @@ export default function SubmitEventPage() {
 
             {/* Venue */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Venue *
               </label>
               <input
@@ -645,13 +645,13 @@ export default function SubmitEventPage() {
                 value={formData.venue}
                 onChange={(e) => updateField('venue', e.target.value)}
                 placeholder="e.g., The Turning Point"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               />
             </div>
 
             {/* Email */}
             <div>
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Your Email *
               </label>
               <input
@@ -660,7 +660,7 @@ export default function SubmitEventPage() {
                 value={formData.submitterEmail}
                 onChange={(e) => updateField('submitterEmail', e.target.value)}
                 placeholder="your@email.com"
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               />
               <p className="text-xs text-stone-500 mt-1">
                 We&apos;ll only use this to contact you about your submission if needed
@@ -670,11 +670,11 @@ export default function SubmitEventPage() {
 
           {/* Optional Fields Section */}
           <div>
-            <h2 className="font-semibold text-stone-900 mb-4">Additional Details (Optional)</h2>
+            <h2 className="font-semibold text-ink mb-4">Additional Details (Optional)</h2>
 
             {/* Description */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Description
               </label>
               <textarea
@@ -682,7 +682,7 @@ export default function SubmitEventPage() {
                 value={formData.description}
                 onChange={(e) => updateField('description', e.target.value)}
                 placeholder="Tell us more about this event..."
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               />
             </div>
 
@@ -690,25 +690,25 @@ export default function SubmitEventPage() {
             {!formData.isRecurring && (
               <div className="grid grid-cols-2 gap-4 mb-4">
                 <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
+                  <label className="block text-sm font-medium text-ink mb-1">
                     End Date
                   </label>
                   <input
                     type="date"
                     value={formData.endDate}
                     onChange={(e) => updateField('endDate', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
+                  <label className="block text-sm font-medium text-ink mb-1">
                     End Time
                   </label>
                   <input
                     type="time"
                     value={formData.endTime}
                     onChange={(e) => updateField('endTime', e.target.value)}
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                   />
                 </div>
               </div>
@@ -717,7 +717,7 @@ export default function SubmitEventPage() {
             {/* Address & City */}
             <div className="grid grid-cols-2 gap-4 mb-4">
               <div>
-                <label className="block text-sm font-medium text-stone-700 mb-1">
+                <label className="block text-sm font-medium text-ink mb-1">
                   Address
                 </label>
                 <input
@@ -725,31 +725,31 @@ export default function SubmitEventPage() {
                   value={formData.address}
                   onChange={(e) => updateField('address', e.target.value)}
                   placeholder="123 Main Street"
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-stone-700 mb-1">
+                <label className="block text-sm font-medium text-ink mb-1">
                   City
                 </label>
                 <input
                   type="text"
                   value={formData.city}
                   onChange={(e) => updateField('city', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                 />
               </div>
             </div>
 
             {/* Category */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Category
               </label>
               <select
                 value={formData.category}
                 onChange={(e) => updateField('category', e.target.value)}
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               >
                 {Object.entries(categoryLabels).map(([value, label]) => (
                   <option key={value} value={value}>
@@ -767,7 +767,7 @@ export default function SubmitEventPage() {
                   id="isFree"
                   checked={formData.isFree}
                   onChange={(e) => updateField('isFree', e.target.checked)}
-                  className="rounded border-stone-300 text-orange-500 focus:ring-orange-500"
+                  className="rounded border-stone-300 text-terra focus:ring-terra"
                 />
                 <label htmlFor="isFree" className="text-sm text-stone-700">
                   This is a free event
@@ -779,7 +779,7 @@ export default function SubmitEventPage() {
                   placeholder="e.g., $20, $15-$30, Free"
                   value={formData.price}
                   onChange={(e) => updateField('price', e.target.value)}
-                  className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                  className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                 />
               )}
             </div>
@@ -791,7 +791,7 @@ export default function SubmitEventPage() {
                 id="isFamilyFriendly"
                 checked={formData.isFamilyFriendly}
                 onChange={(e) => updateField('isFamilyFriendly', e.target.checked)}
-                className="rounded border-stone-300 text-orange-500 focus:ring-orange-500"
+                className="rounded border-stone-300 text-terra focus:ring-terra"
               />
               <label htmlFor="isFamilyFriendly" className="text-sm text-stone-700">
                 Family-friendly event
@@ -800,7 +800,7 @@ export default function SubmitEventPage() {
 
             {/* Event URL */}
             <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
+              <label className="block text-sm font-medium text-ink mb-1">
                 Event Website or More Info
               </label>
               <input
@@ -808,7 +808,7 @@ export default function SubmitEventPage() {
                 value={formData.sourceUrl}
                 onChange={(e) => updateField('sourceUrl', e.target.value)}
                 placeholder="https://..."
-                className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
               />
             </div>
 
@@ -830,7 +830,7 @@ export default function SubmitEventPage() {
                   }}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                     uploadMode === 'url'
-                      ? 'bg-orange-500 text-white'
+                      ? 'bg-terra text-white'
                       : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
                   }`}
                 >
@@ -844,7 +844,7 @@ export default function SubmitEventPage() {
                   }}
                   className={`px-4 py-2 rounded-lg font-medium transition-colors ${
                     uploadMode === 'file'
-                      ? 'bg-orange-500 text-white'
+                      ? 'bg-terra text-white'
                       : 'bg-stone-100 text-stone-700 hover:bg-stone-200'
                   }`}
                 >
@@ -860,7 +860,7 @@ export default function SubmitEventPage() {
                     value={formData.imageUrl}
                     onChange={(e) => updateField('imageUrl', e.target.value)}
                     placeholder="https://example.com/image.jpg"
-                    className="w-full px-4 py-2 border border-stone-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-orange-500"
+                    className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
                   />
                   <p className="text-xs text-stone-500 mt-1">
                     Paste a link to an image for your event
@@ -878,8 +878,8 @@ export default function SubmitEventPage() {
                     onDrop={handleDrop}
                     className={`border-2 border-dashed rounded-lg p-6 text-center transition-colors ${
                       dragActive
-                        ? 'border-orange-500 bg-orange-50'
-                        : 'border-stone-300 hover:border-orange-400'
+                        ? 'border-terra bg-cream'
+                        : 'border-sand hover:border-terra/40'
                     }`}
                   >
                     <input
@@ -900,7 +900,7 @@ export default function SubmitEventPage() {
                             <svg className="w-12 h-12 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
                             </svg>
-                            <p className="font-medium text-stone-900">{selectedFile.name}</p>
+                            <p className="font-medium text-ink">{selectedFile.name}</p>
                             <p className="text-sm text-stone-500">
                               {(selectedFile.size / 1024 / 1024).toFixed(2)} MB
                             </p>
@@ -911,7 +911,7 @@ export default function SubmitEventPage() {
                                 setSelectedFile(null)
                                 setPreviewUrl('')
                               }}
-                              className="text-sm text-orange-600 hover:text-orange-700 font-medium"
+                              className="text-sm text-terra hover:text-harvest font-medium"
                             >
                               Choose Different File
                             </button>
@@ -943,7 +943,7 @@ export default function SubmitEventPage() {
 
               {/* Upload Progress */}
               {uploadProgress && (
-                <div className="mt-3 bg-orange-50 border border-orange-200 text-orange-700 px-4 py-3 rounded-lg flex items-center gap-2">
+                <div className="mt-3 bg-cream border border-harvest/30 text-harvest px-4 py-3 rounded-lg flex items-center gap-2">
                   <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
@@ -959,7 +959,7 @@ export default function SubmitEventPage() {
                   <img
                     src={previewUrl || formData.imageUrl}
                     alt="Event preview"
-                    className="w-full max-w-md rounded-lg border border-stone-200"
+                    className="w-full max-w-md rounded-lg border border-sand"
                     onError={(e) => {
                       const target = e.target as HTMLImageElement
                       target.style.display = 'none'
@@ -975,7 +975,7 @@ export default function SubmitEventPage() {
             <button
               type="submit"
               disabled={saving}
-              className="flex-1 px-6 py-3 bg-orange-500 text-white rounded-lg font-medium hover:bg-orange-600 disabled:opacity-50 transition-colors"
+              className="flex-1 px-6 py-3 bg-terra text-white rounded-lg font-medium hover:bg-terra/90 disabled:opacity-50 transition-colors"
             >
               {saving ? 'Submitting...' : 'Submit Event for Review'}
             </button>

--- a/src/components/ActivityCard.tsx
+++ b/src/components/ActivityCard.tsx
@@ -34,12 +34,12 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
       href={activity.websiteUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="block bg-white rounded-xl border border-stone-200 p-4 hover:shadow-md hover:border-orange-200 transition-all"
+      className="block bg-surface rounded-xl border border-sand p-4 hover:shadow-md hover:border-terra/30 transition-all"
     >
       <div className="flex gap-4">
         {/* Activity image or category icon fallback */}
         {activity.imageUrl ? (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-stone-100">
+          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-oat">
             <img
               src={activity.imageUrl}
               alt={activity.title}
@@ -54,7 +54,7 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
 
         <div className="flex-1 min-w-0">
           {/* Title */}
-          <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
+          <h3 className="font-display font-semibold text-ink line-clamp-2 leading-tight">
             {activity.title}
           </h3>
 
@@ -66,7 +66,7 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
           )}
 
           {/* Venue and location */}
-          <p className="text-sm text-stone-500 mt-0.5">
+          <p className="text-sm text-muted mt-0.5">
             {activity.venue}
             {activity.city !== 'Nyack' && <span> · {activity.city}</span>}
           </p>
@@ -82,7 +82,7 @@ export default function ActivityCard({ activity }: ActivityCardProps) {
                 Free
               </span>
             ) : activity.price ? (
-              <span className="text-xs text-stone-500">{activity.price}</span>
+              <span className="text-xs text-muted">{activity.price}</span>
             ) : null}
 
             {activity.isFamilyFriendly && (

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -11,12 +11,12 @@ export default function BottomNav() {
 
   return (
     <>
-      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-stone-200 px-4 py-2 z-50">
+      <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-forest border-t border-forest/50 px-4 py-2 z-50">
         <div className="flex justify-around">
           <Link
             href="/"
             className={`flex flex-col items-center py-2 px-4 ${
-              isEventsActive ? 'text-orange-500' : 'text-stone-500'
+              isEventsActive ? 'text-terra' : 'text-oat/50'
             }`}
           >
             <svg
@@ -37,7 +37,7 @@ export default function BottomNav() {
           <Link
             href="/activities"
             className={`flex flex-col items-center py-2 px-4 ${
-              isActivitiesActive ? 'text-orange-500' : 'text-stone-500'
+              isActivitiesActive ? 'text-terra' : 'text-oat/50'
             }`}
           >
             <svg

--- a/src/components/DateTabs.tsx
+++ b/src/components/DateTabs.tsx
@@ -55,8 +55,8 @@ export default function DateTabs({
             px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors
             ${
               !isCustomActive && activeFilter === tab.value
-                ? 'bg-orange-500 text-white'
-                : 'bg-white text-stone-600 hover:bg-stone-100 border border-stone-200'
+                ? 'bg-terra text-cream'
+                : 'bg-surface text-stone-600 hover:bg-oat border border-sand'
             }
           `}
         >
@@ -66,11 +66,11 @@ export default function DateTabs({
 
       {/* Custom tab / active date pill */}
       {isCustomActive ? (
-        <div className="flex items-center gap-1 px-3 py-2 rounded-full bg-orange-500 text-white text-sm font-medium whitespace-nowrap flex-shrink-0">
+        <div className="flex items-center gap-1 px-3 py-2 rounded-full bg-terra text-cream text-sm font-medium whitespace-nowrap flex-shrink-0">
           <span>{formatCustomDatePill(customDate)}</span>
           <button
             onClick={onCustomDateClear}
-            className="ml-1 hover:bg-orange-600 rounded-full p-0.5 transition-colors"
+            className="ml-1 hover:bg-terra/80 rounded-full p-0.5 transition-colors"
             aria-label="Clear custom date"
           >
             <X className="w-3 h-3" />
@@ -79,19 +79,19 @@ export default function DateTabs({
       ) : (
         <Drawer.Root open={drawerOpen} onOpenChange={setDrawerOpen}>
           <Drawer.Trigger asChild>
-            <button className="px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-white text-stone-600 hover:bg-stone-100 border border-stone-200 flex-shrink-0">
+            <button className="px-4 py-2 rounded-full text-sm font-medium whitespace-nowrap transition-colors bg-surface text-stone-600 hover:bg-oat border border-sand flex-shrink-0">
               Custom
             </button>
           </Drawer.Trigger>
           <Drawer.Portal>
             <Drawer.Overlay className="fixed inset-0 bg-black/40 z-40" />
-            <Drawer.Content className="fixed bottom-0 left-0 right-0 bg-white rounded-t-2xl z-50 outline-none">
+            <Drawer.Content className="fixed bottom-0 left-0 right-0 bg-surface rounded-t-2xl z-50 outline-none">
               <Drawer.Title className="sr-only">Pick a Date</Drawer.Title>
               <div className="pt-3 flex justify-center">
-                <div className="w-10 h-1 bg-stone-200 rounded-full" />
+                <div className="w-10 h-1 bg-sand rounded-full" />
               </div>
               <div className="p-4 pb-8">
-                <h3 className="text-base font-semibold text-stone-900 mb-3 text-center">
+                <h3 className="text-base font-display font-semibold text-ink mb-3 text-center">
                   Pick a Date
                 </h3>
                 <div className="flex justify-center">

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -42,14 +42,14 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
       rel="noopener noreferrer"
       className={`block rounded-xl border p-4 transition-all ${
         event.isMarquee
-          ? 'bg-amber-50 border-amber-300 hover:shadow-md hover:border-amber-400'
-          : 'bg-white border-stone-200 hover:shadow-md hover:border-orange-200'
+          ? 'bg-cream border-harvest/30 hover:shadow-md hover:border-harvest/60'
+          : 'bg-surface border-sand hover:shadow-md hover:border-terra/30'
       }`}
     >
       <div className="flex gap-4">
         {/* Event image or category icon fallback */}
         {event.imageUrl ? (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-stone-100">
+          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-oat">
             <img
               src={event.imageUrl}
               alt={title}
@@ -65,12 +65,12 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
         <div className="flex-1 min-w-0">
           {/* Title */}
           <div className="flex items-center gap-2">
-            <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight">
+            <h3 className="font-display font-semibold text-ink line-clamp-2 leading-tight">
               {title}
             </h3>
             {event.isMarquee && (
-              <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-200 text-amber-800">
-                ⭐ Big Event
+              <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-harvest/20 text-harvest">
+                ★ Big Event
               </span>
             )}
           </div>
@@ -82,7 +82,7 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
           </p>
 
           {/* Venue and location */}
-          <p className="text-sm text-stone-500 mt-0.5">
+          <p className="text-sm text-muted mt-0.5">
             {event.venue}
             {event.city !== 'Nyack' && <span> · {event.city}</span>}
           </p>
@@ -98,7 +98,7 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
                 Free
               </span>
             ) : event.price ? (
-              <span className="text-xs text-stone-500">{event.price}</span>
+              <span className="text-xs text-muted">{event.price}</span>
             ) : null}
 
             {event.isFamilyFriendly && (

--- a/src/components/FallbackBanner.tsx
+++ b/src/components/FallbackBanner.tsx
@@ -8,21 +8,21 @@ interface FallbackBannerProps {
 
 export default function FallbackBanner({ onDismiss }: FallbackBannerProps) {
   return (
-    <div className="relative flex gap-4 px-5 py-4 mb-6 bg-orange-50 border-2 border-orange-200 rounded-xl">
-      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center">
-        <MoonStar className="w-5 h-5 text-orange-500" />
+    <div className="relative flex gap-4 px-5 py-4 mb-6 bg-oat border border-sand rounded-xl">
+      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-harvest/15 flex items-center justify-center">
+        <MoonStar className="w-5 h-5 text-harvest" />
       </div>
       <div className="flex-1 min-w-0">
-        <p className="font-semibold text-orange-900 leading-snug">
+        <p className="font-semibold text-ink leading-snug">
           Nothing happening in Nyack tonight
         </p>
-        <p className="text-sm text-orange-700 mt-0.5">
+        <p className="text-sm text-muted mt-0.5">
           Here&apos;s what&apos;s coming up this week instead.
         </p>
       </div>
       <button
         onClick={onDismiss}
-        className="flex-shrink-0 text-orange-400 hover:text-orange-600 transition-colors mt-0.5"
+        className="flex-shrink-0 text-muted hover:text-ink transition-colors mt-0.5"
         aria-label="Dismiss"
       >
         <X className="w-4 h-4" />

--- a/src/components/FeatureHighlights.tsx
+++ b/src/components/FeatureHighlights.tsx
@@ -35,11 +35,11 @@ export default function FeatureHighlights() {
       {features.map((feature, index) => (
         <div
           key={index}
-          className="bg-white/90 backdrop-blur-sm rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow"
+          className="bg-surface border border-sand rounded-xl p-6 hover:shadow-md transition-shadow"
         >
-          <div className="text-orange-500 mb-4">{feature.icon}</div>
-          <h3 className="text-xl font-bold text-stone-900 mb-2">{feature.title}</h3>
-          <p className="text-stone-700 text-sm">{feature.description}</p>
+          <div className="text-terra mb-4">{feature.icon}</div>
+          <h3 className="font-display font-semibold text-xl text-ink mb-2">{feature.title}</h3>
+          <p className="text-stone-600 text-sm">{feature.description}</p>
         </div>
       ))}
     </div>

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -26,7 +26,7 @@ export default function FilterBar({ filters, onFiltersChange }: FilterBarProps) 
       <select
         value={filters.category}
         onChange={(e) => updateFilter('category', e.target.value as Category | 'ALL')}
-        className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        className="px-3 py-2 rounded-lg border border-sand bg-surface text-sm text-ink focus:outline-none focus:ring-2 focus:ring-terra"
       >
         <option value="ALL">All Categories</option>
         {Object.entries(categoryLabels).map(([value, label]) => (
@@ -40,7 +40,7 @@ export default function FilterBar({ filters, onFiltersChange }: FilterBarProps) 
       <select
         value={filters.priceFilter}
         onChange={(e) => updateFilter('priceFilter', e.target.value as Filters['priceFilter'])}
-        className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        className="px-3 py-2 rounded-lg border border-sand bg-surface text-sm text-ink focus:outline-none focus:ring-2 focus:ring-terra"
       >
         <option value="all">Any Price</option>
         <option value="free">Free Only</option>
@@ -51,7 +51,7 @@ export default function FilterBar({ filters, onFiltersChange }: FilterBarProps) 
       <select
         value={filters.location}
         onChange={(e) => updateFilter('location', e.target.value as Filters['location'])}
-        className="px-3 py-2 rounded-lg border border-stone-200 bg-white text-sm text-stone-700 focus:outline-none focus:ring-2 focus:ring-orange-500"
+        className="px-3 py-2 rounded-lg border border-sand bg-surface text-sm text-ink focus:outline-none focus:ring-2 focus:ring-terra"
       >
         <option value="all">All Locations</option>
         <option value="nyack">Nyack Only</option>
@@ -66,7 +66,7 @@ export default function FilterBar({ filters, onFiltersChange }: FilterBarProps) 
           ${
             filters.familyFriendly
               ? 'bg-green-100 text-green-700 border border-green-300'
-              : 'bg-white text-stone-600 border border-stone-200 hover:bg-stone-50'
+              : 'bg-surface text-stone-600 border border-sand hover:bg-oat'
           }
         `}
       >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -34,17 +34,17 @@ export default function Header() {
   }
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b border-stone-200 shadow-sm">
-      <div className="max-w-4xl mx-auto px-4 py-2 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-2xl font-bold text-orange-500">Nyack</span>
-          <span className="text-2xl font-light text-stone-700">Today</span>
+    <header className="sticky top-0 z-50 bg-forest border-b border-forest shadow-sm">
+      <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-1.5">
+          <span className="text-2xl font-display font-semibold text-oat tracking-tight">Nyack</span>
+          <span className="text-2xl font-display font-semibold text-sage tracking-tight">Today</span>
         </Link>
 
         {/* Mobile menu button */}
         <button
           onClick={() => setMenuOpen(!menuOpen)}
-          className="md:hidden p-2 text-stone-600 hover:text-stone-900"
+          className="md:hidden p-2 text-oat/70 hover:text-oat"
           aria-label="Toggle menu"
         >
           <svg
@@ -75,25 +75,25 @@ export default function Header() {
         <nav className="hidden md:flex items-center gap-6">
           <button
             onClick={handleEventsClick}
-            className="text-stone-600 hover:text-orange-500 transition-colors cursor-pointer"
+            className="text-sm text-oat/70 hover:text-oat transition-colors cursor-pointer"
           >
             Events
           </button>
           <Link
             href="/activities"
-            className="text-stone-600 hover:text-orange-500 transition-colors"
+            className="text-sm text-oat/70 hover:text-oat transition-colors"
           >
             Always Available
           </Link>
           <Link
             href="/submit"
-            className="text-stone-600 hover:text-orange-500 transition-colors"
+            className="text-sm text-oat/70 hover:text-oat transition-colors"
           >
             Submit Event
           </Link>
           <button
             onClick={handleSubscribeClick}
-            className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-1.5 rounded-lg text-sm font-medium transition-colors cursor-pointer"
+            className="bg-terra hover:bg-terra/90 text-cream px-4 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer"
           >
             Subscribe
           </button>
@@ -102,30 +102,30 @@ export default function Header() {
 
       {/* Mobile nav */}
       {menuOpen && (
-        <nav className="md:hidden border-t border-stone-200 bg-white">
+        <nav className="md:hidden border-t border-forest/50 bg-deep">
           <button
             onClick={handleEventsClick}
-            className="block w-full text-left px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
+            className="block w-full text-left px-4 py-3 text-oat/80 hover:bg-forest/50 hover:text-oat text-sm"
           >
             Events
           </button>
           <Link
             href="/activities"
-            className="block px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
+            className="block px-4 py-3 text-oat/80 hover:bg-forest/50 hover:text-oat text-sm"
             onClick={() => setMenuOpen(false)}
           >
             Always Available
           </Link>
           <Link
             href="/submit"
-            className="block px-4 py-3 text-stone-600 hover:bg-stone-50 hover:text-orange-500"
+            className="block px-4 py-3 text-oat/80 hover:bg-forest/50 hover:text-oat text-sm"
             onClick={() => setMenuOpen(false)}
           >
             Submit Event
           </Link>
           <button
             onClick={handleSubscribeClick}
-            className="block w-full text-left px-4 py-3 text-orange-500 hover:bg-orange-50 font-medium"
+            className="block w-full text-left px-4 py-3 text-terra font-medium text-sm hover:bg-forest/50"
           >
             Subscribe to Weekly Digest
           </button>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,20 +1,28 @@
 export default function Hero() {
   return (
-    <div className="relative">
-      {/* Background gradient */}
-      <div className="absolute inset-0 bg-gradient-to-br from-orange-200 via-amber-300 to-orange-400 -z-10" />
+    <div className="relative bg-forest overflow-hidden">
+      {/* Decorative blob */}
+      <svg
+        className="absolute right-0 top-0 w-72 h-72 pointer-events-none"
+        viewBox="0 0 360 360"
+        aria-hidden="true"
+      >
+        <ellipse cx="180" cy="170" rx="150" ry="115" fill="#8FBD9E" opacity="0.12" transform="rotate(18 180 170)" />
+        <ellipse cx="225" cy="135" rx="80" ry="65" fill="#F5F0E8" opacity="0.08" />
+        <ellipse cx="120" cy="220" rx="50" ry="40" fill="#D4622A" opacity="0.12" />
+        <circle cx="265" cy="220" r="22" fill="#C8973A" opacity="0.18" />
+      </svg>
 
-      {/* Content */}
-      <div className="flex flex-col items-center justify-center px-4 pt-10 pb-4 max-w-6xl mx-auto w-full">
-        {/* Hero headline */}
-        <div className="text-center">
-          <h1 className="text-4xl md:text-6xl font-bold text-stone-900 mb-3">
-            Nyack Today
-          </h1>
-          <p className="text-lg md:text-xl text-stone-800">
-            Your guide to what&apos;s happening in our corner of the Hudson Valley
-          </p>
-        </div>
+      <div className="relative z-10 flex flex-col items-center justify-center px-4 pt-12 pb-6 max-w-4xl mx-auto w-full">
+        <p className="text-xs font-medium uppercase tracking-widest text-sage mb-4">
+          Nyack, NY
+        </p>
+        <h1 className="font-display font-semibold text-4xl md:text-6xl text-oat text-center leading-tight tracking-tight mb-3">
+          What&apos;s on in Nyack.
+        </h1>
+        <p className="text-sage text-base md:text-lg text-center max-w-sm">
+          Your guide to what&apos;s happening in our corner of the Hudson Valley
+        </p>
       </div>
     </div>
   )

--- a/src/components/MarqueeSection.tsx
+++ b/src/components/MarqueeSection.tsx
@@ -75,15 +75,15 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
   if (events.length === 0) return null
 
   return (
-    <div className="mb-8 bg-amber-50 border border-amber-200 rounded-2xl p-4">
+    <div className="mb-8 bg-cream border border-harvest/30 rounded-2xl p-4">
       <div className="flex items-center justify-between mb-3">
-        <h2 className="text-sm font-semibold text-amber-700 uppercase tracking-wide">
-          ⭐ Big Events
+        <h2 className="text-xs font-semibold text-harvest uppercase tracking-widest">
+          ★ Big Events
         </h2>
         <div className="flex items-center gap-3">
           <button
             onClick={onShowAll}
-            className="text-sm text-amber-700 hover:text-amber-900 font-medium underline underline-offset-2"
+            className="text-sm text-terra hover:text-terra/70 font-medium"
           >
             See all →
           </button>
@@ -92,7 +92,7 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
               <button
                 onClick={scrollLeft}
                 disabled={atStart}
-                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+                className="w-7 h-7 rounded-full bg-oat border border-sand flex items-center justify-center text-stone-600 text-lg leading-none hover:bg-surface disabled:opacity-30 disabled:cursor-not-allowed transition-all"
                 aria-label="Previous"
               >
                 ‹
@@ -100,7 +100,7 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
               <button
                 onClick={scrollRight}
                 disabled={atEnd}
-                className="w-7 h-7 rounded-full bg-white border border-amber-200 flex items-center justify-center text-amber-700 text-lg leading-none hover:bg-amber-100 disabled:opacity-30 disabled:cursor-not-allowed transition-all"
+                className="w-7 h-7 rounded-full bg-oat border border-sand flex items-center justify-center text-stone-600 text-lg leading-none hover:bg-surface disabled:opacity-30 disabled:cursor-not-allowed transition-all"
                 aria-label="Next"
               >
                 ›
@@ -127,10 +127,10 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
               href={event.sourceUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex-shrink-0 w-[calc(33.333%-8px)] min-w-[200px] bg-white border border-amber-200 rounded-xl p-3 hover:shadow-md hover:border-amber-400 transition-all flex flex-col"
+              className="flex-shrink-0 w-[calc(33.333%-8px)] min-w-[200px] bg-surface border border-sand rounded-xl p-3 hover:shadow-md hover:border-terra/30 transition-all flex flex-col"
             >
               {event.imageUrl ? (
-                <div className="w-full aspect-video rounded-lg overflow-hidden bg-stone-100 mb-3">
+                <div className="w-full aspect-video rounded-lg overflow-hidden bg-oat mb-3">
                   <img src={event.imageUrl} alt={title} className="w-full h-full object-cover" />
                 </div>
               ) : (
@@ -139,13 +139,13 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
                 </div>
               )}
 
-              <h3 className="font-semibold text-stone-900 line-clamp-2 leading-tight text-sm flex-1">
+              <h3 className="font-display font-semibold text-ink line-clamp-2 leading-tight text-sm flex-1">
                 {title}
               </h3>
-              <p className="text-xs text-stone-500 mt-1">
+              <p className="text-xs text-muted mt-1">
                 {formatDate(startDate)} · {formatTime(startDate)}
               </p>
-              <p className="text-xs text-stone-500 truncate mt-0.5">
+              <p className="text-xs text-muted truncate mt-0.5">
                 {decodeHtmlEntities(event.venue)}
               </p>
               <div className="flex items-center gap-1.5 mt-2 flex-wrap">

--- a/src/components/SubscribeSection.tsx
+++ b/src/components/SubscribeSection.tsx
@@ -33,15 +33,15 @@ export default function SubscribeSection() {
   }
 
   return (
-    <div className="rounded-2xl bg-gradient-to-br from-orange-50 to-amber-50 border border-orange-200 p-6">
-      <h2 className="text-xl font-bold text-stone-900 mb-1">Get Nyack in Your Inbox</h2>
-      <p className="text-stone-600 text-sm mb-4">
+    <div className="rounded-2xl bg-deep border border-forest p-6">
+      <h2 className="font-display font-semibold text-xl text-oat mb-1">Get Nyack in Your Inbox</h2>
+      <p className="text-sage text-sm mb-4">
         Every Thursday morning, a quick roundup of what&apos;s happening in Nyack this weekend and beyond — straight to your inbox.
       </p>
 
       <div aria-live="polite">
         {status === 'success' ? (
-          <div className="flex items-center gap-2 text-green-700 font-medium">
+          <div className="flex items-center gap-2 text-sage font-medium">
             <svg className="w-5 h-5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
               <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
             </svg>
@@ -58,12 +58,12 @@ export default function SubscribeSection() {
               placeholder="you@example.com"
               required
               disabled={status === 'loading'}
-              className="flex-1 rounded-lg border border-stone-200 bg-white px-3 py-2 text-sm text-stone-900 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-50"
+              className="flex-1 rounded-xl border border-forest/50 bg-forest/30 px-3 py-2 text-sm text-oat placeholder-sage/60 focus:outline-none focus:border-terra disabled:opacity-50"
             />
             <button
               type="submit"
               disabled={status === 'loading'}
-              className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors disabled:opacity-50 whitespace-nowrap"
+              className="bg-terra hover:bg-terra/90 text-cream px-5 py-2 rounded-xl text-sm font-medium transition-colors disabled:opacity-50 whitespace-nowrap"
             >
               {status === 'loading' ? 'Subscribing...' : 'Subscribe'}
             </button>
@@ -71,7 +71,7 @@ export default function SubscribeSection() {
         )}
 
         {status === 'error' && (
-          <p className="mt-2 text-sm text-red-600">{errorMessage}</p>
+          <p className="mt-2 text-sm text-red-400">{errorMessage}</p>
         )}
       </div>
     </div>

--- a/src/lib/utils/email.ts
+++ b/src/lib/utils/email.ts
@@ -2,1160 +2,324 @@ import { Resend } from 'resend'
 import { Event, EventSubmission } from '@prisma/client'
 import { categoryLabels, categoryIcons } from './categories'
 
-/**
- * Send email notification when a new event is submitted
- * Uses graceful degradation - logs errors but doesn't throw
- */
-export async function sendEventSubmissionEmail(
-  submission: EventSubmission
-): Promise<void> {
-  // Validate environment variables
-  const apiKey = process.env.RESEND_API_KEY
-  const adminEmail = process.env.ADMIN_EMAIL
-
-  if (!apiKey || !adminEmail) {
-    console.warn(
-      'Email notification skipped: RESEND_API_KEY or ADMIN_EMAIL not configured'
-    )
-    return
-  }
-
-  try {
-    const resend = new Resend(apiKey)
-
-    const htmlContent = generateHtmlEmail(submission)
-    const textContent = generatePlainTextEmail(submission)
-
-    await resend.emails.send({
-      from: 'Nyack Today <submissions@nyacktoday.com>',
-      to: adminEmail,
-      subject: `New Event Submission: ${submission.title}`,
-      html: htmlContent,
-      text: textContent,
-    })
-
-    console.log(`Event submission email sent for: ${submission.title}`)
-  } catch (error) {
-    // Log error but don't throw - email is not critical to submission success
-    console.error('Failed to send event submission email:', error)
-  }
+// ─── Design System Tokens ────────────────────────────────────────────────────
+const DS = {
+  forest:  '#1E3A2F',
+  deep:    '#2C5240',
+  terra:   '#D4622A',
+  harvest: '#C8973A',
+  oat:     '#F5F0E8',
+  surface: '#FDF8F0',
+  ink:     '#1A1A14',
+  muted:   '#7A7468',
+  sand:    '#DDD6C6',
+  sage:    '#8FBD9E',
+  cream:   '#FEF0E6',
 }
+
+// ─── Shared Layout Helpers ────────────────────────────────────────────────────
+
+function emailShell(headerContent: string, bodyContent: string, footerContent: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
+      line-height: 1.6;
+      color: ${DS.ink};
+      background-color: ${DS.oat};
+      margin: 0;
+      padding: 0;
+    }
+    .wrapper {
+      max-width: 600px;
+      margin: 0 auto;
+      background-color: ${DS.oat};
+    }
+    a { color: ${DS.terra}; }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    ${headerContent}
+    ${bodyContent}
+    ${footerContent}
+  </div>
+</body>
+</html>`
+}
+
+function emailHeader(title: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `
+  <div style="background-color: ${DS.forest}; padding: 28px 24px 24px;">
+    <div style="font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: ${DS.sage}; margin-bottom: 10px;">
+      <a href="${siteUrl}" style="color: ${DS.sage}; text-decoration: none;">Nyack Today</a>
+    </div>
+    <div style="font-size: 22px; font-weight: 700; color: ${DS.oat}; line-height: 1.2;">${title}</div>
+  </div>`
+}
+
+function emailFooter(extra?: string): string {
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  return `
+  <div style="margin-top: 0; padding: 20px 24px; background-color: ${DS.deep}; font-size: 12px; color: ${DS.sage}; text-align: center;">
+    <div><strong style="color: ${DS.oat};">Nyack Today</strong> &middot; <a href="${siteUrl}" style="color: ${DS.sage};">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
+    ${extra ? `<div style="margin-top: 8px;">${extra}</div>` : ''}
+  </div>`
+}
+
+function emailSection(content: string): string {
+  return `
+  <div style="margin: 0 24px 16px; padding: 16px; background: ${DS.surface}; border-left: 3px solid ${DS.terra}; border-radius: 0 6px 6px 0;">
+    ${content}
+  </div>`
+}
+
+function emailSectionTitle(title: string): string {
+  return `<div style="font-size: 10px; font-weight: 600; color: ${DS.muted}; text-transform: uppercase; letter-spacing: 0.12em; margin-bottom: 12px;">${title}</div>`
+}
+
+function emailField(label: string, value: string): string {
+  return `<div style="margin-bottom: 10px;"><span style="font-weight: 600; color: ${DS.muted};">${label}</span> <span style="color: ${DS.ink};">${value}</span></div>`
+}
+
+function emailCtaButton(href: string, label: string): string {
+  return `
+  <div style="text-align: center; margin: 24px 0;">
+    <a href="${href}" style="display: inline-block; padding: 13px 28px; background: ${DS.terra}; color: ${DS.cream} !important; text-decoration: none; border-radius: 20px; font-weight: 600; font-size: 14px;">${label}</a>
+  </div>`
+}
+
+// ─── Submission Email (to admin) ──────────────────────────────────────────────
 
 function generateHtmlEmail(submission: EventSubmission): string {
   const categoryLabel = categoryLabels[submission.category]
   const categoryIcon = categoryIcons[submission.category]
 
-  // Format dates
   const startDate = new Date(submission.startDate).toLocaleString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
   })
-
   const endDate = submission.endDate
     ? new Date(submission.endDate).toLocaleString('en-US', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZoneName: 'short',
+        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
       })
     : null
-
   const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
+    dateStyle: 'medium', timeStyle: 'short',
   })
+  const priceDisplay = submission.isFree ? 'Free' : submission.price || 'Not specified'
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
-  // Format price
-  const priceDisplay = submission.isFree
-    ? 'Free'
-    : submission.price || 'Not specified'
-
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-      line-height: 1.6;
-      color: #333;
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-      font-weight: 600;
-    }
-    .content {
-      padding: 20px;
-    }
-    .event-title {
-      font-size: 22px;
-      font-weight: 700;
-      color: #1c1917;
-      margin: 0 0 20px 0;
-    }
-    .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
-    }
-    .section-title {
-      font-size: 14px;
-      font-weight: 600;
-      color: #57534e;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 0 0 12px 0;
-    }
-    .field {
-      margin-bottom: 12px;
-    }
-    .label {
-      font-weight: 600;
-      color: #57534e;
-      margin-right: 8px;
-    }
-    .value {
-      color: #1c1917;
-    }
-    .badge {
-      display: inline-block;
-      padding: 4px 12px;
-      border-radius: 12px;
-      font-size: 14px;
-      font-weight: 500;
-      background-color: #fed7aa;
-      color: #9a3412;
-    }
-    .admin-link {
-      display: inline-block;
-      margin-top: 20px;
-      padding: 12px 24px;
-      background: #f97316;
-      color: white;
-      text-decoration: none;
-      border-radius: 8px;
-      font-weight: 600;
-    }
-    .admin-link:hover {
-      background: #ea580c;
-    }
-    .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
-      font-size: 12px;
-      color: #78716c;
-    }
-    a {
-      color: #f97316;
-      text-decoration: underline;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>📬 New Event Submission</h1>
+  const body = `
+  <div style="padding: 24px 24px 0;">
+    <div style="font-size: 20px; font-weight: 700; color: ${DS.ink}; margin-bottom: 20px;">${escapeHtml(submission.title)}</div>
   </div>
 
-  <div class="content">
-    <h2 class="event-title">${escapeHtml(submission.title)}</h2>
+  ${emailSection(`
+    ${emailSectionTitle('Required Information')}
+    ${emailField('Start:', startDate)}
+    ${endDate ? emailField('End:', endDate) : ''}
+    ${emailField('Venue:', escapeHtml(submission.venue))}
+    ${submission.address ? emailField('Address:', `${escapeHtml(submission.address)}, ${escapeHtml(submission.city)}`) : ''}
+    ${emailField('Submitter:', `<a href="mailto:${escapeHtml(submission.submitterEmail)}">${escapeHtml(submission.submitterEmail)}</a>`)}
+  `)}
 
-    <div class="section">
-      <div class="section-title">Required Information</div>
+  ${emailSection(`
+    ${emailSectionTitle('Additional Details')}
+    ${submission.description ? emailField('Description:', escapeHtml(submission.description).replace(/\n/g, '<br>')) : ''}
+    ${emailField('Category:', `<span style="background: ${DS.cream}; color: ${DS.terra}; padding: 2px 10px; border-radius: 10px; font-size: 13px; font-weight: 500;">${categoryIcon} ${categoryLabel}</span>`)}
+    ${emailField('Price:', escapeHtml(priceDisplay))}
+    ${submission.isFamilyFriendly ? emailField('Family-Friendly:', 'Yes') : ''}
+    ${submission.sourceUrl ? emailField('Event URL:', `<a href="${escapeHtml(submission.sourceUrl)}">${escapeHtml(submission.sourceUrl)}</a>`) : ''}
+  `)}
 
-      <div class="field">
-        <span class="label">📅 Start Date & Time:</span>
-        <span class="value">${startDate}</span>
-      </div>
+  ${emailCtaButton(`${siteUrl}/admin/submissions`, 'Review in Admin Dashboard')}
 
-      ${
-        endDate
-          ? `
-      <div class="field">
-        <span class="label">🏁 End Date & Time:</span>
-        <span class="value">${endDate}</span>
-      </div>
-      `
-          : ''
-      }
+  <div style="padding: 0 24px 24px; font-size: 12px; color: ${DS.muted};">
+    <div>Submission ID: ${submission.id}</div>
+    <div>Submitted: ${submittedAt}</div>
+    <div>Status: ${submission.status}</div>
+  </div>`
 
-      <div class="field">
-        <span class="label">📍 Venue:</span>
-        <span class="value">${escapeHtml(submission.venue)}</span>
-      </div>
-
-      ${
-        submission.address
-          ? `
-      <div class="field">
-        <span class="label">🗺️ Address:</span>
-        <span class="value">${escapeHtml(submission.address)}, ${escapeHtml(submission.city)}</span>
-      </div>
-      `
-          : ''
-      }
-
-      <div class="field">
-        <span class="label">📧 Submitter Email:</span>
-        <span class="value"><a href="mailto:${escapeHtml(submission.submitterEmail)}">${escapeHtml(submission.submitterEmail)}</a></span>
-      </div>
-    </div>
-
-    ${
-      submission.description ||
-      submission.category !== 'OTHER' ||
-      submission.price ||
-      submission.isFree ||
-      submission.isFamilyFriendly ||
-      submission.sourceUrl
-        ? `
-    <div class="section">
-      <div class="section-title">Additional Details</div>
-
-      ${
-        submission.description
-          ? `
-      <div class="field">
-        <span class="label">📝 Description:</span>
-        <div class="value">${escapeHtml(submission.description).replace(/\n/g, '<br>')}</div>
-      </div>
-      `
-          : ''
-      }
-
-      <div class="field">
-        <span class="label">${categoryIcon} Category:</span>
-        <span class="badge">${categoryLabel}</span>
-      </div>
-
-      <div class="field">
-        <span class="label">💰 Price:</span>
-        <span class="value">${escapeHtml(priceDisplay)}</span>
-      </div>
-
-      ${
-        submission.isFamilyFriendly
-          ? `
-      <div class="field">
-        <span class="label">👨‍👩‍👧‍👦 Family-Friendly:</span>
-        <span class="value">Yes</span>
-      </div>
-      `
-          : ''
-      }
-
-      ${
-        submission.sourceUrl
-          ? `
-      <div class="field">
-        <span class="label">🔗 Event URL:</span>
-        <span class="value"><a href="${escapeHtml(submission.sourceUrl)}" target="_blank">${escapeHtml(submission.sourceUrl)}</a></span>
-      </div>
-      `
-          : ''
-      }
-    </div>
-    `
-        : ''
-    }
-
-    <div style="text-align: center; margin-top: 30px;">
-      <a href="${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/admin/submissions" class="admin-link">
-        Review Submission in Admin Dashboard
-      </a>
-    </div>
-  </div>
-
-  <div class="footer">
-    <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Submitted:</strong> ${submittedAt}</div>
-    <div><strong>Status:</strong> ${submission.status}</div>
-  </div>
-</body>
-</html>
-  `.trim()
+  return emailShell(emailHeader('New Event Submission'), body, emailFooter())
 }
 
-function generatePlainTextEmail(submission: EventSubmission): string {
-  const categoryLabel = categoryLabels[submission.category]
-  const categoryIcon = categoryIcons[submission.category]
+// ─── Confirmation Email (to submitter) ────────────────────────────────────────
 
-  const startDate = new Date(submission.startDate).toLocaleString('en-US', {
-    weekday: 'long',
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  })
-
-  const endDate = submission.endDate
-    ? new Date(submission.endDate).toLocaleString('en-US', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-        timeZoneName: 'short',
-      })
-    : null
-
-  const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
-
-  const priceDisplay = submission.isFree
-    ? 'Free'
-    : submission.price || 'Not specified'
-
-  return `
-NEW EVENT SUBMISSION
-====================
-
-${submission.title}
-
-REQUIRED INFORMATION
---------------------
-Start Date & Time: ${startDate}
-${endDate ? `End Date & Time: ${endDate}` : ''}
-Venue: ${submission.venue}
-${submission.address ? `Address: ${submission.address}, ${submission.city}` : ''}
-Submitter Email: ${submission.submitterEmail}
-
-ADDITIONAL DETAILS
-------------------
-${submission.description ? `Description: ${submission.description}\n` : ''}
-Category: ${categoryIcon} ${categoryLabel}
-Price: ${priceDisplay}
-${submission.isFamilyFriendly ? 'Family-Friendly: Yes\n' : ''}
-${submission.sourceUrl ? `Event URL: ${submission.sourceUrl}\n` : ''}
-
-ADMIN ACTIONS
--------------
-Review in Dashboard: ${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/admin/submissions
-
-Submission ID: ${submission.id}
-Submitted: ${submittedAt}
-Status: ${submission.status}
-  `.trim()
-}
-
-/**
- * Escape HTML special characters to prevent XSS
- */
-function escapeHtml(text: string): string {
-  const map: Record<string, string> = {
-    '&': '&amp;',
-    '<': '&lt;',
-    '>': '&gt;',
-    '"': '&quot;',
-    "'": '&#039;',
-  }
-  return text.replace(/[&<>"']/g, (char) => map[char])
-}
-
-/**
- * Format recurrence pattern for display in emails
- * Example: "Repeats every Tuesday, Thursday" or "Repeats every Monday until March 30, 2026"
- */
-function formatRecurrencePattern(
-  isRecurring: boolean,
-  recurrenceDays: number[],
-  recurrenceEndDate: Date | null
-): string {
-  if (!isRecurring || !recurrenceDays || recurrenceDays.length === 0) {
-    return ''
-  }
-
-  const dayNames = [
-    'Sunday',
-    'Monday',
-    'Tuesday',
-    'Wednesday',
-    'Thursday',
-    'Friday',
-    'Saturday',
-  ]
-  const days = recurrenceDays.map((d) => dayNames[d]).join(', ')
-
-  if (recurrenceEndDate) {
-    const endDateStr = new Date(recurrenceEndDate).toLocaleDateString('en-US', {
-      month: 'long',
-      day: 'numeric',
-      year: 'numeric',
-    })
-    return `Repeats every ${days} until ${endDateStr}`
-  }
-  return `Repeats every ${days}`
-}
-
-/**
- * Generate HTML email for submission confirmation
- */
 function generateConfirmationHtmlEmail(submission: EventSubmission): string {
   const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
+    dateStyle: 'medium', timeStyle: 'short',
   })
-
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
   } else {
     dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
     })
   }
-
-  // Format time
   const timeDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
+    hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
   })
 
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-      line-height: 1.6;
-      color: #333;
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-      font-weight: 600;
-    }
-    .content {
-      padding: 20px;
-    }
-    .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
-    }
-    .section-title {
-      font-size: 14px;
-      font-weight: 600;
-      color: #57534e;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 0 0 12px 0;
-    }
-    .field {
-      margin-bottom: 12px;
-    }
-    .label {
-      font-weight: 600;
-      color: #57534e;
-      margin-right: 8px;
-    }
-    .value {
-      color: #1c1917;
-    }
-    .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
-      font-size: 12px;
-      color: #78716c;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>✉️ Event Submission Received</h1>
-  </div>
-
-  <div class="content">
+  const body = `
+  <div style="padding: 24px 24px 0; color: ${DS.ink};">
     <p>Hi there!</p>
-
     <p>Thank you for submitting your event to Nyack Today. We've received your submission and our team will review it shortly.</p>
+  </div>
 
-    <div class="section">
-      <div class="section-title">What You Submitted</div>
+  ${emailSection(`
+    ${emailSectionTitle('What You Submitted')}
+    ${emailField('Title:', escapeHtml(submission.title))}
+    ${emailField(submission.isRecurring ? 'Schedule:' : 'Date:', dateDisplay)}
+    ${emailField('Time:', timeDisplay)}
+    ${emailField('Venue:', escapeHtml(submission.venue))}
+  `)}
 
-      <div class="field">
-        <span class="label">Title:</span>
-        <span class="value">${escapeHtml(submission.title)}</span>
-      </div>
+  ${emailSection(`
+    ${emailSectionTitle('What Happens Next')}
+    <ul style="margin: 0; padding-left: 18px; color: ${DS.ink};">
+      <li style="margin-bottom: 6px;">Our team will review your submission within 24-48 hours</li>
+      <li style="margin-bottom: 6px;">We'll email you when your event is approved or if we need more information</li>
+      <li>Once approved, your event will be live on Nyack Today</li>
+    </ul>
+  `)}
 
-      <div class="field">
-        <span class="label">${submission.isRecurring ? '📅 Schedule:' : '📅 Date:'}</span>
-        <span class="value">${dateDisplay}</span>
-      </div>
-
-      <div class="field">
-        <span class="label">🕐 Time:</span>
-        <span class="value">${timeDisplay}</span>
-      </div>
-
-      <div class="field">
-        <span class="label">📍 Venue:</span>
-        <span class="value">${escapeHtml(submission.venue)}</span>
-      </div>
-    </div>
-
-    <div class="section">
-      <div class="section-title">What Happens Next</div>
-      <ul style="margin: 0; padding-left: 20px;">
-        <li>Our team will review your submission within 24-48 hours</li>
-        <li>We'll send you an email when your event is approved or if we need more information</li>
-        <li>Once approved, your event will be live on Nyack Today for the community to discover</li>
-      </ul>
-    </div>
-
+  <div style="padding: 0 24px 24px; color: ${DS.muted}; font-size: 13px;">
     <p>Questions? Reply to this email or contact us at submissions@nyacktoday.com</p>
-  </div>
+    <div style="margin-top: 16px; font-size: 12px;">
+      <div>Submission ID: ${submission.id}</div>
+      <div>Submitted: ${submittedAt}</div>
+    </div>
+  </div>`
 
-  <div class="footer">
-    <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Submitted:</strong> ${submittedAt}</div>
-  </div>
-</body>
-</html>
-  `.trim()
+  return emailShell(emailHeader('Submission Received'), body, emailFooter())
 }
 
-/**
- * Generate plain text email for submission confirmation
- */
-function generateConfirmationPlainTextEmail(
-  submission: EventSubmission
-): string {
-  const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
+// ─── Approval Email (to submitter) ───────────────────────────────────────────
 
-  // Format date/time or recurrence pattern
-  let dateDisplay: string
-  if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
-  } else {
-    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
-  }
-
-  const timeDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-    timeZoneName: 'short',
-  })
-
-  return `
-EVENT SUBMISSION RECEIVED
-=========================
-
-Hi there!
-
-Thank you for submitting your event to Nyack Today. We've received your submission and our team will review it shortly.
-
-WHAT YOU SUBMITTED
-------------------
-Title: ${submission.title}
-${submission.isRecurring ? 'Schedule:' : 'Date:'} ${dateDisplay}
-Time: ${timeDisplay}
-Venue: ${submission.venue}
-
-WHAT HAPPENS NEXT
-------------------
-- Our team will review your submission within 24-48 hours
-- We'll send you an email when your event is approved or if we need more information
-- Once approved, your event will be live on Nyack Today for the community to discover
-
-Questions? Reply to this email or contact us at submissions@nyacktoday.com
-
-Submission ID: ${submission.id}
-Submitted: ${submittedAt}
-  `.trim()
-}
-
-/**
- * Send confirmation email to submitter when event is submitted
- * Uses graceful degradation - logs errors but doesn't throw
- */
-export async function sendSubmissionConfirmationEmail(
-  submission: EventSubmission
-): Promise<void> {
-  // Validate environment variables
-  const apiKey = process.env.RESEND_API_KEY
-
-  if (!apiKey) {
-    console.warn(
-      'Confirmation email skipped: RESEND_API_KEY not configured'
-    )
-    return
-  }
-
-  try {
-    const resend = new Resend(apiKey)
-
-    const htmlContent = generateConfirmationHtmlEmail(submission)
-    const textContent = generateConfirmationPlainTextEmail(submission)
-
-    await resend.emails.send({
-      from: 'Nyack Today <submissions@nyacktoday.com>',
-      to: submission.submitterEmail,
-      subject: `Event Submission Received - ${submission.title}`,
-      html: htmlContent,
-      text: textContent,
-    })
-
-    console.log(`Confirmation email sent to: ${submission.submitterEmail}`)
-  } catch (error) {
-    // Log error but don't throw - email is not critical to submission success
-    console.error('Failed to send confirmation email:', error)
-  }
-}
-
-/**
- * Generate HTML email for submission approval
- */
-function generateApprovalHtmlEmail(
-  submission: EventSubmission,
-  event: Event
-): string {
+function generateApprovalHtmlEmail(submission: EventSubmission, event: Event): string {
   const approvedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
+    dateStyle: 'medium', timeStyle: 'short',
   })
-
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
   } else {
     dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZoneName: 'short',
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
     })
   }
-
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const eventUrl = submission.isRecurring
-    ? siteUrl // For recurring events, link to homepage
-    : `${siteUrl}/events/${event.id}`
+  const eventUrl = submission.isRecurring ? siteUrl : `${siteUrl}/events/${event.id}`
 
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-      line-height: 1.6;
-      color: #333;
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-      font-weight: 600;
-    }
-    .content {
-      padding: 20px;
-    }
-    .event-title {
-      font-size: 22px;
-      font-weight: 700;
-      color: #1c1917;
-      margin: 20px 0;
-    }
-    .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
-    }
-    .section-title {
-      font-size: 14px;
-      font-weight: 600;
-      color: #57534e;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 0 0 12px 0;
-    }
-    .cta-button {
-      display: inline-block;
-      margin: 30px 0;
-      padding: 14px 28px;
-      background: #f97316;
-      color: white !important;
-      text-decoration: none;
-      border-radius: 8px;
-      font-weight: 600;
-      font-size: 16px;
-    }
-    .cta-button:hover {
-      background: #ea580c;
-    }
-    .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
-      font-size: 12px;
-      color: #78716c;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>🎉 Your Event is Live!</h1>
-  </div>
-
-  <div class="content">
+  const body = `
+  <div style="padding: 24px 24px 0; color: ${DS.ink};">
     <p>Great news! Your event has been approved and is now live on Nyack Today.</p>
-
-    <div class="event-title">${escapeHtml(submission.title)}</div>
-
-    <div class="section">
-      <div>${dateDisplay}</div>
-      <div style="margin-top: 8px;">📍 ${escapeHtml(submission.venue)}</div>
-    </div>
-
-    <div style="text-align: center;">
-      <a href="${eventUrl}" class="cta-button">
-        ${submission.isRecurring ? 'View Nyack Today' : 'View Your Event on Nyack Today'}
-      </a>
-    </div>
-
-    <div class="section">
-      <div class="section-title">Share Your Event</div>
-      <p style="margin: 0;">Help spread the word! Share the link above with friends, family, and on social media.</p>
-    </div>
-
-    <p>Thank you for contributing to the Nyack community! We appreciate you helping locals discover great things to do.</p>
+    <div style="font-size: 20px; font-weight: 700; color: ${DS.ink}; margin: 16px 0 4px;">${escapeHtml(submission.title)}</div>
+    <div style="color: ${DS.muted}; font-size: 14px; margin-bottom: 4px;">${dateDisplay}</div>
+    <div style="color: ${DS.muted}; font-size: 14px;">📍 ${escapeHtml(submission.venue)}</div>
   </div>
 
-  <div class="footer">
-    <div><strong>Event ID:</strong> ${event.id}</div>
-    <div><strong>Approved:</strong> ${approvedAt}</div>
-  </div>
-</body>
-</html>
-  `.trim()
+  ${emailCtaButton(eventUrl, submission.isRecurring ? 'View Nyack Today' : 'View Your Event')}
+
+  ${emailSection(`
+    ${emailSectionTitle('Share Your Event')}
+    <p style="margin: 0; color: ${DS.ink};">Help spread the word! Share the link above with friends, family, and on social media.</p>
+  `)}
+
+  <div style="padding: 0 24px 24px; color: ${DS.muted}; font-size: 13px;">
+    <p>Thank you for contributing to the Nyack community!</p>
+    <div style="font-size: 12px; margin-top: 8px;">
+      <div>Event ID: ${event.id}</div>
+      <div>Approved: ${approvedAt}</div>
+    </div>
+  </div>`
+
+  return emailShell(emailHeader('Your Event is Live! 🎉'), body, emailFooter())
 }
 
-/**
- * Generate plain text email for submission approval
- */
-function generateApprovalPlainTextEmail(
-  submission: EventSubmission,
-  event: Event
-): string {
-  const approvedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
+// ─── Rejection Email (to submitter) ──────────────────────────────────────────
 
-  // Format date/time or recurrence pattern
-  let dateDisplay: string
-  if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
-  } else {
-    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZoneName: 'short',
-    })
-  }
-
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  const eventUrl = submission.isRecurring
-    ? siteUrl
-    : `${siteUrl}/events/${event.id}`
-
-  return `
-YOUR EVENT IS LIVE!
-===================
-
-Great news! Your event has been approved and is now live on Nyack Today.
-
-${submission.title}
-${dateDisplay}
-${submission.venue}
-
-${submission.isRecurring ? 'VIEW NYACK TODAY' : 'VIEW YOUR EVENT'}
-${eventUrl}
-
-SHARE YOUR EVENT
-----------------
-Help spread the word! Share the link above with friends, family, and on social media.
-
-Thank you for contributing to the Nyack community! We appreciate you helping locals discover great things to do.
-
-Event ID: ${event.id}
-Approved: ${approvedAt}
-  `.trim()
-}
-
-/**
- * Send approval email to submitter when event is approved
- * Includes link to live event on the site
- */
-export async function sendSubmissionApprovalEmail(
-  submission: EventSubmission,
-  event: Event
-): Promise<void> {
-  // Validate environment variables
-  const apiKey = process.env.RESEND_API_KEY
-
-  if (!apiKey) {
-    console.warn('Approval email skipped: RESEND_API_KEY not configured')
-    return
-  }
-
-  try {
-    const resend = new Resend(apiKey)
-
-    const htmlContent = generateApprovalHtmlEmail(submission, event)
-    const textContent = generateApprovalPlainTextEmail(submission, event)
-
-    await resend.emails.send({
-      from: 'Nyack Today <submissions@nyacktoday.com>',
-      to: submission.submitterEmail,
-      subject: `Event Approved! ${submission.title} is now live`,
-      html: htmlContent,
-      text: textContent,
-    })
-
-    console.log(`Approval email sent to: ${submission.submitterEmail}`)
-  } catch (error) {
-    // Log error but don't throw - email is not critical
-    console.error('Failed to send approval email:', error)
-  }
-}
-
-/**
- * Generate HTML email for submission rejection
- */
 function generateRejectionHtmlEmail(submission: EventSubmission): string {
   const reviewedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
+    dateStyle: 'medium', timeStyle: 'short',
   })
-
-  // Format date/time or recurrence pattern
   let dateDisplay: string
   if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
   } else {
     dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
     })
   }
-
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
 
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif;
-      line-height: 1.6;
-      color: #333;
-      max-width: 600px;
-      margin: 0 auto;
-      padding: 0;
-    }
-    .header {
-      background-color: #f97316;
-      color: white;
-      padding: 30px 20px;
-      text-align: center;
-    }
-    .header h1 {
-      margin: 0;
-      font-size: 24px;
-      font-weight: 600;
-    }
-    .content {
-      padding: 20px;
-    }
-    .section {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fafaf9;
-      border-left: 4px solid #f97316;
-      border-radius: 4px;
-    }
-    .section-title {
-      font-size: 14px;
-      font-weight: 600;
-      color: #57534e;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      margin: 0 0 12px 0;
-    }
-    .reason-box {
-      margin: 20px 0;
-      padding: 15px;
-      background: #fff7ed;
-      border-left: 4px solid #ea580c;
-      border-radius: 4px;
-    }
-    .footer {
-      margin-top: 30px;
-      padding: 20px;
-      background: #f5f5f4;
-      border-top: 2px solid #e7e5e4;
-      font-size: 12px;
-      color: #78716c;
-    }
-  </style>
-</head>
-<body>
-  <div class="header">
-    <h1>📬 Event Submission Update</h1>
-  </div>
-
-  <div class="content">
+  const body = `
+  <div style="padding: 24px 24px 0; color: ${DS.ink};">
     <p>Hi there,</p>
-
     <p>Thank you for taking the time to submit your event to Nyack Today. After reviewing your submission, we've decided not to add it to our calendar at this time.</p>
-
-    <div class="section">
-      <div class="section-title">Your Submission</div>
-      <div><strong>Title:</strong> ${escapeHtml(submission.title)}</div>
-      <div style="margin-top: 8px;"><strong>${submission.isRecurring ? 'Schedule:' : 'Date:'}</strong> ${dateDisplay}</div>
-      <div style="margin-top: 8px;"><strong>Venue:</strong> ${escapeHtml(submission.venue)}</div>
-    </div>
-
-    ${
-      submission.rejectionReason
-        ? `
-    <div class="reason-box">
-      <div class="section-title">Review Notes</div>
-      <p style="margin: 0;">${escapeHtml(submission.rejectionReason)}</p>
-    </div>
-    `
-        : ''
-    }
-
-    <p>This may be because the event falls outside our geographic focus (Nyack and immediate surrounding areas), doesn't fit our event categories, or we need more information to verify the details.</p>
-
-    <p><strong>Please don't let this discourage you!</strong> We'd love to see future events you're hosting. You can submit another event anytime at ${siteUrl}/submit</p>
-
-    <p>If you have questions or want to discuss this submission, feel free to reply to this email.</p>
   </div>
 
-  <div class="footer">
-    <div><strong>Submission ID:</strong> ${submission.id}</div>
-    <div><strong>Reviewed:</strong> ${reviewedAt}</div>
-  </div>
-</body>
-</html>
-  `.trim()
+  ${emailSection(`
+    ${emailSectionTitle('Your Submission')}
+    ${emailField('Title:', escapeHtml(submission.title))}
+    ${emailField(submission.isRecurring ? 'Schedule:' : 'Date:', dateDisplay)}
+    ${emailField('Venue:', escapeHtml(submission.venue))}
+  `)}
+
+  ${submission.rejectionReason ? `
+  <div style="margin: 0 24px 16px; padding: 16px; background: ${DS.cream}; border-left: 3px solid ${DS.harvest}; border-radius: 0 6px 6px 0;">
+    ${emailSectionTitle('Review Notes')}
+    <p style="margin: 0; color: ${DS.ink};">${escapeHtml(submission.rejectionReason)}</p>
+  </div>` : ''}
+
+  <div style="padding: 0 24px 24px; color: ${DS.ink}; font-size: 14px;">
+    <p>This may be because the event falls outside our geographic focus, doesn't fit our event categories, or we need more information to verify the details.</p>
+    <p><strong>Please don't let this discourage you!</strong> You can submit another event anytime at <a href="${siteUrl}/submit">${siteUrl}/submit</a></p>
+    <p>If you have questions, feel free to reply to this email.</p>
+    <div style="font-size: 12px; color: ${DS.muted}; margin-top: 16px;">
+      <div>Submission ID: ${submission.id}</div>
+      <div>Reviewed: ${reviewedAt}</div>
+    </div>
+  </div>`
+
+  return emailShell(emailHeader('Event Submission Update'), body, emailFooter())
 }
 
-/**
- * Generate plain text email for submission rejection
- */
-function generateRejectionPlainTextEmail(submission: EventSubmission): string {
-  const reviewedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
-    dateStyle: 'medium',
-    timeStyle: 'short',
-  })
-
-  // Format date/time or recurrence pattern
-  let dateDisplay: string
-  if (submission.isRecurring) {
-    const recurrence = formatRecurrencePattern(
-      submission.isRecurring,
-      submission.recurrenceDays,
-      submission.recurrenceEndDate
-    )
-    dateDisplay = recurrence || 'Recurring event'
-  } else {
-    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    })
-  }
-
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-
-  return `
-EVENT SUBMISSION UPDATE
-=======================
-
-Hi there,
-
-Thank you for taking the time to submit your event to Nyack Today. After reviewing your submission, we've decided not to add it to our calendar at this time.
-
-YOUR SUBMISSION
----------------
-Title: ${submission.title}
-${submission.isRecurring ? 'Schedule:' : 'Date:'} ${dateDisplay}
-Venue: ${submission.venue}
-
-${
-    submission.rejectionReason
-      ? `
-REVIEW NOTES
-------------
-${submission.rejectionReason}
-
-`
-      : ''
-  }
-This may be because the event falls outside our geographic focus (Nyack and immediate surrounding areas), doesn't fit our event categories, or we need more information to verify the details.
-
-Please don't let this discourage you! We'd love to see future events you're hosting. You can submit another event anytime at ${siteUrl}/submit
-
-If you have questions or want to discuss this submission, feel free to reply to this email.
-
-Submission ID: ${submission.id}
-Reviewed: ${reviewedAt}
-  `.trim()
-}
-
-// ─── Weekly Digest Emails ────────────────────────────────────────────────────
+// ─── Welcome Email ────────────────────────────────────────────────────────────
 
 function generateWelcomeHtmlEmail(unsubscribeUrl: string): string {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 0; }
-    .header { background-color: #f97316; color: white; padding: 30px 20px; text-align: center; }
-    .header h1 { margin: 0; font-size: 24px; font-weight: 600; }
-    .content { padding: 24px 20px; }
-    .section { margin: 20px 0; padding: 15px; background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; }
-    .cta-button { display: inline-block; margin: 20px 0; padding: 12px 24px; background: #f97316; color: white !important; text-decoration: none; border-radius: 8px; font-weight: 600; }
-    .footer { margin-top: 30px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; }
-    a { color: #f97316; }
-  </style>
-</head>
-<body>
-  <div class="header"><h1>You're in! 🎉</h1></div>
-  <div class="content">
+
+  const body = `
+  <div style="padding: 24px 24px 0; color: ${DS.ink};">
     <p>Thanks for subscribing to the <strong>Nyack Today weekly digest</strong>.</p>
-    <div class="section">
-      Every <strong>Thursday morning</strong> you'll get a quick roundup of what's happening in Nyack and the surrounding area — this weekend and beyond.
-    </div>
+  </div>
+
+  ${emailSection(`
+    Every <strong>Thursday morning</strong> you'll get a quick roundup of what's happening in Nyack and the surrounding area — this weekend and beyond.
+  `)}
+
+  <div style="padding: 0 24px 8px; color: ${DS.ink}; font-size: 14px;">
     <p>In the meantime, check out what's happening right now:</p>
-    <div style="text-align: center;">
-      <a href="${siteUrl}" class="cta-button">Browse Events</a>
-    </div>
   </div>
-  <div class="footer">
-    <div>Nyack Today &middot; <a href="${siteUrl}">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
-    <div style="margin-top: 8px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
-  </div>
-</body>
-</html>`.trim()
+
+  ${emailCtaButton(siteUrl, 'Browse Events')}
+  `
+
+  return emailShell(
+    emailHeader("You're in! 🎉"),
+    body,
+    emailFooter(`<a href="${unsubscribeUrl}" style="color: ${DS.sage};">Unsubscribe</a>`)
+  )
 }
 
 function generateWelcomePlainTextEmail(unsubscribeUrl: string): string {
@@ -1175,28 +339,7 @@ Unsubscribe: ${unsubscribeUrl}
 `.trim()
 }
 
-export async function sendWelcomeEmail(email: string, unsubscribeToken: string): Promise<void> {
-  const apiKey = process.env.RESEND_API_KEY
-  if (!apiKey) {
-    console.warn('Welcome email skipped: RESEND_API_KEY not configured')
-    return
-  }
-  try {
-    const resend = new Resend(apiKey)
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
-    const unsubscribeUrl = `${siteUrl}/api/unsubscribe?token=${unsubscribeToken}`
-    await resend.emails.send({
-      from: 'Nyack Today <submissions@nyacktoday.com>',
-      to: email,
-      subject: "You're subscribed to the Nyack Today weekly digest!",
-      html: generateWelcomeHtmlEmail(unsubscribeUrl),
-      text: generateWelcomePlainTextEmail(unsubscribeUrl),
-    })
-    console.log(`Welcome email sent to: ${email}`)
-  } catch (error) {
-    console.error('Failed to send welcome email:', error)
-  }
-}
+// ─── Weekly Digest ────────────────────────────────────────────────────────────
 
 export function generateDigestHtml(
   events: Event[],
@@ -1208,65 +351,52 @@ export function generateDigestHtml(
 
   const formatEventDate = (date: Date) =>
     new Date(date).toLocaleString('en-US', {
-      weekday: 'short',
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZone: 'America/New_York',
+      weekday: 'short', month: 'short', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZone: 'America/New_York',
     })
 
   const eventRows = events.length === 0
-    ? `<p style="color: #57534e; font-style: italic;">No events found this week — check back next Thursday!</p>`
+    ? `<p style="color: ${DS.muted}; font-style: italic;">No events found this week — check back next Thursday!</p>`
     : events.map((e, i) => `
-      ${i > 0 ? '<hr style="border: none; border-top: 1px solid #e7e5e4; margin: 12px 0;">' : ''}
+      ${i > 0 ? `<hr style="border: none; border-top: 1px solid ${DS.sand}; margin: 14px 0;">` : ''}
       <div style="padding: 4px 0;">
         <div style="margin-bottom: 4px;">
-          <a href="${escapeHtml(e.sourceUrl)}" style="color: #f97316; font-weight: 600; text-decoration: underline; font-size: 16px;">${escapeHtml(e.title)}</a>
-          ${e.isFree ? '<span style="margin-left: 8px; background: #dcfce7; color: #166534; font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: 10px; display: inline-block;">FREE</span>' : ''}
+          <a href="${escapeHtml(e.sourceUrl)}" style="color: ${DS.terra}; font-weight: 600; text-decoration: underline; font-size: 15px;">${escapeHtml(e.title)}</a>
+          ${e.isFree ? `<span style="margin-left: 8px; background: #E8EFE0; color: ${DS.forest}; font-size: 10px; font-weight: 600; padding: 2px 8px; border-radius: 10px; display: inline-block; text-transform: uppercase; letter-spacing: 0.06em;">Free</span>` : ''}
         </div>
-        <div style="color: #57534e; font-size: 14px;">${formatEventDate(e.startDate)}</div>
-        <div style="color: #78716c; font-size: 14px;">${escapeHtml(e.venue)}</div>
+        <div style="color: ${DS.muted}; font-size: 13px; margin-top: 2px;">${formatEventDate(e.startDate)}</div>
+        <div style="color: ${DS.muted}; font-size: 13px;">${escapeHtml(e.venue)}</div>
       </div>`).join('')
 
-  return `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>
-    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Arial, sans-serif; line-height: 1.6; color: #1c1917; max-width: 600px; margin: 0 auto; padding: 0; }
-    a { color: #f97316; }
-  </style>
-</head>
-<body>
-  <div style="background-color: #f97316; color: white; padding: 30px 20px; text-align: center;">
-    <div style="font-size: 13px; font-weight: 500; opacity: 0.85; margin-bottom: 4px; text-transform: uppercase; letter-spacing: 1px;">Nyack Today</div>
-    <h1 style="margin: 0; font-size: 26px; font-weight: 700;">Nyack This Week</h1>
-    <div style="font-size: 15px; margin-top: 6px; opacity: 0.9;">${escapeHtml(weekLabel)}</div>
-  </div>
+  const header = `
+  <div style="background-color: ${DS.forest}; padding: 28px 24px 24px; position: relative;">
+    <div style="font-size: 11px; font-weight: 500; letter-spacing: 0.12em; text-transform: uppercase; color: ${DS.sage}; margin-bottom: 10px;">
+      <a href="${siteUrl}" style="color: ${DS.sage}; text-decoration: none;">Nyack Today</a>
+    </div>
+    <div style="font-size: 24px; font-weight: 700; color: ${DS.oat}; line-height: 1.2; margin-bottom: 6px;">Nyack This Week</div>
+    <div style="font-size: 14px; color: ${DS.sage};">${escapeHtml(weekLabel)}</div>
+  </div>`
 
-  <div style="padding: 24px 20px;">
-    <div style="background: #fafaf9; border-left: 4px solid #f97316; border-radius: 4px; padding: 16px; margin-bottom: 24px; color: #44403c; font-size: 15px; line-height: 1.7;">
+  const body = `
+  <div style="padding: 24px 24px 0;">
+    <div style="background: ${DS.surface}; border-left: 3px solid ${DS.terra}; border-radius: 0 6px 6px 0; padding: 16px; margin-bottom: 24px; color: ${DS.ink}; font-size: 15px; line-height: 1.7;">
       ${escapeHtml(aiSummary)}
     </div>
 
-    <h2 style="font-size: 18px; font-weight: 700; color: #1c1917; margin: 0 0 16px 0;">Upcoming Events</h2>
+    <h2 style="font-size: 11px; font-weight: 600; color: ${DS.muted}; text-transform: uppercase; letter-spacing: 0.12em; margin: 0 0 16px 0;">Upcoming Events</h2>
     ${eventRows}
-
-    <div style="text-align: center; margin-top: 28px;">
-      <a href="${siteUrl}" style="display: inline-block; padding: 12px 28px; background: #f97316; color: white; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 15px;">See All Events</a>
-    </div>
   </div>
 
-  <div style="margin-top: 20px; padding: 20px; background: #f5f5f4; border-top: 2px solid #e7e5e4; font-size: 12px; color: #78716c; text-align: center;">
-    <div><strong>Nyack Today</strong> &middot; <a href="${siteUrl}" style="color: #78716c;">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
+  ${emailCtaButton(siteUrl, 'See All Events')}`
+
+  const footer = `
+  <div style="margin-top: 0; padding: 20px 24px; background-color: ${DS.deep}; font-size: 12px; color: ${DS.sage}; text-align: center;">
+    <div><strong style="color: ${DS.oat};">Nyack Today</strong> &middot; <a href="${siteUrl}" style="color: ${DS.sage};">${siteUrl.replace(/^https?:\/\//, '')}</a></div>
     <div style="margin-top: 6px;">You're receiving this because you subscribed at Nyack Today.</div>
-    <div style="margin-top: 6px;"><a href="${unsubscribeUrl}" style="color: #78716c;">Unsubscribe</a></div>
-  </div>
-</body>
-</html>`.trim()
+    <div style="margin-top: 6px;"><a href="${unsubscribeUrl}" style="color: ${DS.sage};">Unsubscribe</a></div>
+  </div>`
+
+  return emailShell(header, body, footer)
 }
 
 export function generateDigestText(
@@ -1306,38 +436,305 @@ Unsubscribe: ${unsubscribeUrl}
 `.trim()
 }
 
-/**
- * Send rejection email to submitter when event is rejected
- * Includes optional reason from admin
- */
-export async function sendSubmissionRejectionEmail(
-  submission: EventSubmission
-): Promise<void> {
-  // Validate environment variables
-  const apiKey = process.env.RESEND_API_KEY
+// ─── Send Functions ───────────────────────────────────────────────────────────
 
+export async function sendEventSubmissionEmail(submission: EventSubmission): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  const adminEmail = process.env.ADMIN_EMAIL
+  if (!apiKey || !adminEmail) {
+    console.warn('Email notification skipped: RESEND_API_KEY or ADMIN_EMAIL not configured')
+    return
+  }
+  try {
+    const resend = new Resend(apiKey)
+    await resend.emails.send({
+      from: 'Nyack Today <submissions@nyacktoday.com>',
+      to: adminEmail,
+      subject: `New Event Submission: ${submission.title}`,
+      html: generateHtmlEmail(submission),
+      text: generatePlainTextEmail(submission),
+    })
+    console.log(`Event submission email sent for: ${submission.title}`)
+  } catch (error) {
+    console.error('Failed to send event submission email:', error)
+  }
+}
+
+export async function sendSubmissionConfirmationEmail(submission: EventSubmission): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('Confirmation email skipped: RESEND_API_KEY not configured')
+    return
+  }
+  try {
+    const resend = new Resend(apiKey)
+    await resend.emails.send({
+      from: 'Nyack Today <submissions@nyacktoday.com>',
+      to: submission.submitterEmail,
+      subject: `Event Submission Received - ${submission.title}`,
+      html: generateConfirmationHtmlEmail(submission),
+      text: generateConfirmationPlainTextEmail(submission),
+    })
+    console.log(`Confirmation email sent to: ${submission.submitterEmail}`)
+  } catch (error) {
+    console.error('Failed to send confirmation email:', error)
+  }
+}
+
+export async function sendSubmissionApprovalEmail(submission: EventSubmission, event: Event): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('Approval email skipped: RESEND_API_KEY not configured')
+    return
+  }
+  try {
+    const resend = new Resend(apiKey)
+    await resend.emails.send({
+      from: 'Nyack Today <submissions@nyacktoday.com>',
+      to: submission.submitterEmail,
+      subject: `Event Approved! ${submission.title} is now live`,
+      html: generateApprovalHtmlEmail(submission, event),
+      text: generateApprovalPlainTextEmail(submission, event),
+    })
+    console.log(`Approval email sent to: ${submission.submitterEmail}`)
+  } catch (error) {
+    console.error('Failed to send approval email:', error)
+  }
+}
+
+export async function sendSubmissionRejectionEmail(submission: EventSubmission): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
   if (!apiKey) {
     console.warn('Rejection email skipped: RESEND_API_KEY not configured')
     return
   }
-
   try {
     const resend = new Resend(apiKey)
-
-    const htmlContent = generateRejectionHtmlEmail(submission)
-    const textContent = generateRejectionPlainTextEmail(submission)
-
     await resend.emails.send({
       from: 'Nyack Today <submissions@nyacktoday.com>',
       to: submission.submitterEmail,
       subject: `Event Submission Update - ${submission.title}`,
-      html: htmlContent,
-      text: textContent,
+      html: generateRejectionHtmlEmail(submission),
+      text: generateRejectionPlainTextEmail(submission),
     })
-
     console.log(`Rejection email sent to: ${submission.submitterEmail}`)
   } catch (error) {
-    // Log error but don't throw - email is not critical
     console.error('Failed to send rejection email:', error)
   }
+}
+
+export async function sendWelcomeEmail(email: string, unsubscribeToken: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) {
+    console.warn('Welcome email skipped: RESEND_API_KEY not configured')
+    return
+  }
+  try {
+    const resend = new Resend(apiKey)
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+    const unsubscribeUrl = `${siteUrl}/api/unsubscribe?token=${unsubscribeToken}`
+    await resend.emails.send({
+      from: 'Nyack Today <submissions@nyacktoday.com>',
+      to: email,
+      subject: "You're subscribed to the Nyack Today weekly digest!",
+      html: generateWelcomeHtmlEmail(unsubscribeUrl),
+      text: generateWelcomePlainTextEmail(unsubscribeUrl),
+    })
+    console.log(`Welcome email sent to: ${email}`)
+  } catch (error) {
+    console.error('Failed to send welcome email:', error)
+  }
+}
+
+// ─── Plain Text Emails ────────────────────────────────────────────────────────
+
+function generatePlainTextEmail(submission: EventSubmission): string {
+  const categoryLabel = categoryLabels[submission.category]
+  const categoryIcon = categoryIcons[submission.category]
+  const startDate = new Date(submission.startDate).toLocaleString('en-US', {
+    weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+  })
+  const endDate = submission.endDate
+    ? new Date(submission.endDate).toLocaleString('en-US', {
+        weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+        hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+      })
+    : null
+  const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
+    dateStyle: 'medium', timeStyle: 'short',
+  })
+  const priceDisplay = submission.isFree ? 'Free' : submission.price || 'Not specified'
+
+  return `
+NEW EVENT SUBMISSION
+====================
+
+${submission.title}
+
+REQUIRED INFORMATION
+--------------------
+Start Date & Time: ${startDate}
+${endDate ? `End Date & Time: ${endDate}` : ''}
+Venue: ${submission.venue}
+${submission.address ? `Address: ${submission.address}, ${submission.city}` : ''}
+Submitter Email: ${submission.submitterEmail}
+
+ADDITIONAL DETAILS
+------------------
+${submission.description ? `Description: ${submission.description}\n` : ''}
+Category: ${categoryIcon} ${categoryLabel}
+Price: ${priceDisplay}
+${submission.isFamilyFriendly ? 'Family-Friendly: Yes\n' : ''}
+${submission.sourceUrl ? `Event URL: ${submission.sourceUrl}\n` : ''}
+
+ADMIN ACTIONS
+-------------
+Review in Dashboard: ${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/admin/submissions
+
+Submission ID: ${submission.id}
+Submitted: ${submittedAt}
+Status: ${submission.status}
+  `.trim()
+}
+
+function generateConfirmationPlainTextEmail(submission: EventSubmission): string {
+  const submittedAt = new Date(submission.submittedAt).toLocaleString('en-US', {
+    dateStyle: 'medium', timeStyle: 'short',
+  })
+  let dateDisplay: string
+  if (submission.isRecurring) {
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
+  } else {
+    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    })
+  }
+  const timeDisplay = new Date(submission.startDate).toLocaleString('en-US', {
+    hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+  })
+
+  return `
+EVENT SUBMISSION RECEIVED
+=========================
+
+Hi there!
+
+Thank you for submitting your event to Nyack Today.
+
+WHAT YOU SUBMITTED
+------------------
+Title: ${submission.title}
+${submission.isRecurring ? 'Schedule:' : 'Date:'} ${dateDisplay}
+Time: ${timeDisplay}
+Venue: ${submission.venue}
+
+WHAT HAPPENS NEXT
+------------------
+- Our team will review your submission within 24-48 hours
+- We'll email you when your event is approved
+- Once approved, your event will be live on Nyack Today
+
+Questions? Reply to this email or contact us at submissions@nyacktoday.com
+
+Submission ID: ${submission.id}
+Submitted: ${submittedAt}
+  `.trim()
+}
+
+function generateApprovalPlainTextEmail(submission: EventSubmission, event: Event): string {
+  const approvedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
+    dateStyle: 'medium', timeStyle: 'short',
+  })
+  let dateDisplay: string
+  if (submission.isRecurring) {
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
+  } else {
+    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+      hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+    })
+  }
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+  const eventUrl = submission.isRecurring ? siteUrl : `${siteUrl}/events/${event.id}`
+
+  return `
+YOUR EVENT IS LIVE!
+===================
+
+Great news! Your event has been approved and is now live on Nyack Today.
+
+${submission.title}
+${dateDisplay}
+${submission.venue}
+
+${submission.isRecurring ? 'VIEW NYACK TODAY' : 'VIEW YOUR EVENT'}
+${eventUrl}
+
+Thank you for contributing to the Nyack community!
+
+Event ID: ${event.id}
+Approved: ${approvedAt}
+  `.trim()
+}
+
+function generateRejectionPlainTextEmail(submission: EventSubmission): string {
+  const reviewedAt = new Date(submission.reviewedAt || new Date()).toLocaleString('en-US', {
+    dateStyle: 'medium', timeStyle: 'short',
+  })
+  let dateDisplay: string
+  if (submission.isRecurring) {
+    dateDisplay = formatRecurrencePattern(submission.isRecurring, submission.recurrenceDays, submission.recurrenceEndDate) || 'Recurring event'
+  } else {
+    dateDisplay = new Date(submission.startDate).toLocaleString('en-US', {
+      weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+    })
+  }
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'
+
+  return `
+EVENT SUBMISSION UPDATE
+=======================
+
+Hi there,
+
+Thank you for submitting your event to Nyack Today. After reviewing, we've decided not to add it to our calendar at this time.
+
+YOUR SUBMISSION
+---------------
+Title: ${submission.title}
+${submission.isRecurring ? 'Schedule:' : 'Date:'} ${dateDisplay}
+Venue: ${submission.venue}
+
+${submission.rejectionReason ? `REVIEW NOTES\n------------\n${submission.rejectionReason}\n\n` : ''}You can submit another event anytime at ${siteUrl}/submit
+
+Submission ID: ${submission.id}
+Reviewed: ${reviewedAt}
+  `.trim()
+}
+
+// ─── Utilities ────────────────────────────────────────────────────────────────
+
+function escapeHtml(text: string): string {
+  const map: Record<string, string> = {
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;',
+  }
+  return text.replace(/[&<>"']/g, (char) => map[char])
+}
+
+function formatRecurrencePattern(
+  isRecurring: boolean,
+  recurrenceDays: number[],
+  recurrenceEndDate: Date | null
+): string {
+  if (!isRecurring || !recurrenceDays || recurrenceDays.length === 0) return ''
+  const dayNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+  const days = recurrenceDays.map((d) => dayNames[d]).join(', ')
+  if (recurrenceEndDate) {
+    const endDateStr = new Date(recurrenceEndDate).toLocaleDateString('en-US', {
+      month: 'long', day: 'numeric', year: 'numeric',
+    })
+    return `Repeats every ${days} until ${endDateStr}`
+  }
+  return `Repeats every ${days}`
 }


### PR DESCRIPTION
## Summary

- Replace orange/stone palette with the new design system: forest green (`#1E3A2F`) for nav/hero, terracotta (`#D4622A`) for CTAs, oat cream (`#F5F0E8`) for backgrounds, sage (`#8FBD9E`) for accents
- Swap Geist fonts for **Plus Jakarta Sans** (body) and **Fraunces** (display headings)
- Update all 16 components and pages to use the new Tailwind color tokens (`bg-forest`, `bg-terra`, `bg-oat`, `bg-surface`, `text-sage`, etc.)
- Rewrite all 6 HTML email templates (submission, confirmation, approval, rejection, welcome, digest) with the same palette — forest header, terra buttons, oat background, deep green footer
- Refactor `email.ts` to use shared `emailShell` / `emailHeader` / `emailFooter` / `emailSection` helpers to keep future style changes in one place

## Test plan

- [ ] Home page: forest green header, hero, oat background, terra active date tab, terra subscribe button
- [ ] Event cards: surface/sand border, display font titles, harvest marquee badge
- [ ] Subscribe section: deep green background, terra CTA
- [ ] Bottom nav (mobile): forest background, terra active icon
- [ ] Activities page: updated filters and card styles
- [ ] Submit page: terra buttons, surface form background
- [ ] Email templates render correctly in an email client preview (check Resend dashboard or trigger a test submission)

🤖 Generated with [Claude Code](https://claude.ai/code)