### PR TITLE
Always show date on event cards

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -220,7 +220,7 @@ export default function Home() {
     return 'No events found for this time period'
   }
 
-  const showDate = !!customDate || (dateFilter !== 'tonight' && dateFilter !== 'tomorrow')
+  const showDate = true
 
   return (
     <div className="min-h-screen">


### PR DESCRIPTION
Fixes issue where dates were hidden on event cards when filtering by tonight, tomorrow, or big events.

The `showDate` variable in `src/app/page.tsx` was conditionally hiding dates for those filters. Changed to always show the date.

Closes #74

Generated with [Claude Code](https://claude.ai/code)