### PR TITLE
fix: handle 4-digit year in nyacknewsandviews time parsing

### DIFF
--- a/src/lib/scrapers/nyacknewsandviews.ts
+++ b/src/lib/scrapers/nyacknewsandviews.ts
@@ -34,9 +34,9 @@ const MONTH_MAP: Record<string, number> = {
 function parseDateFromText(text: string, postDate: Date): Date | null {
   const t = text.replace(/\./g, '').toLowerCase()
 
-  // Full date: optional weekday, Month Day, optional time
+  // Full date: optional weekday, Month Day, optional year, optional time
   const fullMatch = t.match(
-    /(?:(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)[,\s]+)?(\w+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:[,\s]+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm))?/
+    /(?:(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday)[,\s]+)?(\w+)\s+(\d{1,2})(?:st|nd|rd|th)?(?:[,\s]+\d{4})?(?:[,\s]+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*(am|pm))?/
   )
   if (fullMatch) {
     const monthStr = fullMatch[1].toLowerCase()


### PR DESCRIPTION
Fixes #76

When article dates include a year (e.g. "April 19, 2025 at 4 PM"), the time regex would try to match "2025" as the hour, causing the time group to fail and fall back to noon. Added an optional year-skipping group to the regex.

Generated with [Claude Code](https://claude.ai/code)