### PR TITLE
fix: improve dedup to catch cross-venue duplicates and noisy titles

### DIFF
--- a/src/lib/dedup.ts
+++ b/src/lib/dedup.ts
@@ -1,6 +1,16 @@
 import { Event } from '@prisma/client'
 import { stringSimilarity, normalizeVenue, normalizeTitle } from './scrapers/utils'
 
+const GENERIC_VENUE_NAMES = new Set([
+  'nyack', 'south nyack', 'upper nyack', 'west nyack',
+  'garnerville', 'piermont', 'tarrytown', 'sleepy hollow',
+  'rockland county', 'westchester',
+])
+
+function isGenericVenue(venue: string): boolean {
+  return GENERIC_VENUE_NAMES.has(normalizeVenue(venue))
+}
+
 export interface DuplicateGroup {
   winner: Event
   losers: Event[]
@@ -75,39 +85,27 @@ export function findDuplicateGroups(events: Event[]): DuplicateGroup[] {
     if (ra !== rb) parent.set(rb, ra)
   }
 
-  // Within each day, group events by similar venue then check title similarity
+  // Within each day, compare all pairs of events.
+  // Require venue similarity unless at least one event uses a generic city-level venue name.
   for (const dayEvents of byDate.values()) {
-    // Build venue groups
-    const venueGroups: Event[][] = []
-    for (const event of dayEvents) {
-      const normVenue = normalizeVenue(event.venue)
-      let placed = false
-      for (const group of venueGroups) {
-        const repVenue = normalizeVenue(group[0].venue)
-        if (stringSimilarity(normVenue, repVenue) >= VENUE_THRESHOLD) {
-          group.push(event)
-          placed = true
-          break
-        }
-      }
-      if (!placed) venueGroups.push([event])
-    }
+    for (let i = 0; i < dayEvents.length; i++) {
+      for (let j = i + 1; j < dayEvents.length; j++) {
+        const a = dayEvents[i]
+        const b = dayEvents[j]
 
-    // Within each venue group, find duplicate title pairs
-    for (const group of venueGroups) {
-      if (group.length < 2) continue
-      for (let i = 0; i < group.length; i++) {
-        for (let j = i + 1; j < group.length; j++) {
-          const a = group[i]
-          const b = group[j]
-          const normA = normalizeTitle(a.title, a.venue)
-          const normB = normalizeTitle(b.title, b.venue)
-          const titleSim = stringSimilarity(normA, normB)
-          const isDuplicate =
-            titleSim >= TITLE_THRESHOLD ||
-            (normA.length > 0 && normB.length > 0 && (normA.includes(normB) || normB.includes(normA)))
-          if (isDuplicate) union(a.id, b.id)
+        const eitherGeneric = isGenericVenue(a.venue) || isGenericVenue(b.venue)
+        if (!eitherGeneric) {
+          const venueSim = stringSimilarity(normalizeVenue(a.venue), normalizeVenue(b.venue))
+          if (venueSim < VENUE_THRESHOLD) continue
         }
+
+        const normA = normalizeTitle(a.title, a.venue)
+        const normB = normalizeTitle(b.title, b.venue)
+        const titleSim = stringSimilarity(normA, normB)
+        const isDuplicate =
+          titleSim >= TITLE_THRESHOLD ||
+          (normA.length > 0 && normB.length > 0 && (normA.includes(normB) || normB.includes(normA)))
+        if (isDuplicate) union(a.id, b.id)
       }
     }
   }

--- a/src/lib/scrapers/utils.ts
+++ b/src/lib/scrapers/utils.ts
@@ -76,6 +76,12 @@ export function normalizeTitle(title: string, venue?: string): string {
 
   let normalized = title.toLowerCase().trim()
 
+  // Normalize ampersand to 'and'
+  normalized = normalized.replace(/\s*&\s*/g, ' and ')
+
+  // Strip parenthetical content (e.g. "(benefitting The Angel)", "(outdoor)")
+  normalized = normalized.replace(/\s*\([^)]*\)/g, '').trim()
+
   // Remove common prefixes
   for (const prefix of prefixes) {
     if (normalized.startsWith(prefix)) {
@@ -109,10 +115,17 @@ export function normalizeTitle(title: string, venue?: string): string {
     normalized = normalized.replace(regex, '').trim()
   }
 
-  // Remove common words that don't help identify events
-  const fillerWords = ['the', 'a', 'an', 'at', 'in', 'on', 'presents', 'featuring']
+  // Strip ordinal numbers (1st, 2nd, 3rd, 25th, etc.)
+  normalized = normalized.replace(/\b\d+(?:st|nd|rd|th)\b/gi, '').trim()
+
+  // Remove common words that don't help identify events.
+  // Strip punctuation off each word first so "presents:" matches "presents".
+  const fillerWords = new Set(['the', 'a', 'an', 'at', 'in', 'on', 'of', 'to', 'presents', 'featuring', 'annual', 'benefit', 'benefitting'])
   const words = normalized.split(/\s+/)
-  normalized = words.filter(w => !fillerWords.includes(w)).join(' ')
+  normalized = words
+    .map(w => w.replace(/[^\w]/g, ''))
+    .filter(w => w.length > 0 && !fillerWords.has(w))
+    .join(' ')
 
   // Normalize whitespace
   normalized = normalized.replace(/\s+/g, ' ').trim()


### PR DESCRIPTION
## Summary

- **Generic venue bypass**: scrapers that record `Nyack` or `Garnerville` as the venue (instead of a real venue name) were being silently excluded from dedup comparisons — now pairwise title comparison runs whenever either event has a city-level venue
- **`normalizeTitle` improvements**: normalize `&` → `and`, strip parenthetical suffixes like `(benefitting The Angel)`, strip ordinal prefixes like `25th`, strip punctuation off words before filler-word matching (so `Presents:` is now caught), and expand filler words to include `annual`, `benefit`, `of`, `to`, etc.
- **Catches these previously-missed duplicates**: Garden Club plant sale, Garner Arts Festival, Joseph Alessi & Scott Marino, GraceMusic Presents Sputter Box Ensemble

## Test plan

- [ ] Run dedup dry-run via admin panel and confirm the four duplicate groups above now appear
- [ ] Confirm no obviously unrelated events are grouped together (false positives)
- [ ] Run `npm run build` — no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)