### PR TITLE
feat: support multi-date showings in event submission + poster scan

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -137,6 +137,10 @@ model EventSubmission {
   sourceUrl       String?
   imageUrl        String?
 
+  // Multiple showings (e.g. a play with 8 performances)
+  // startDate holds the first showing; extra showings go here
+  additionalDates     DateTime[]
+
   // Recurrence fields (for recurring events like "Every Tuesday")
   isRecurring         Boolean   @default(false)
   recurrenceDays      Int[]     // Array of day numbers: 0=Sun, 1=Mon, 2=Tue, ..., 6=Sat

--- a/src/app/admin/submissions/page.tsx
+++ b/src/app/admin/submissions/page.tsx
@@ -29,6 +29,8 @@ interface EventSubmission {
   reviewedAt: string | null
   rejectionReason: string | null
   approvedEventId: string | null
+  // Multiple showings
+  additionalDates: string[]
   // Recurrence fields
   isRecurring: boolean
   recurrenceDays: number[]
@@ -107,7 +109,9 @@ export default function AdminSubmissionsPage() {
   }, [filter])
 
   const approveSubmission = async (submission: EventSubmission) => {
-    if (!confirm(`Approve "${submission.title}"? This will create a new event.`)) {
+    const totalShowings = 1 + (submission.additionalDates?.length ?? 0)
+    const eventWord = totalShowings > 1 ? `${totalShowings} events` : 'a new event'
+    if (!confirm(`Approve "${submission.title}"? This will create ${eventWord}.`)) {
       return
     }
 
@@ -370,18 +374,42 @@ export default function AdminSubmissionsPage() {
               )}
 
               <div className="grid md:grid-cols-2 gap-4 mb-4 text-sm">
-                <div>
-                  <span className="font-medium text-stone-700">Date:</span>{' '}
-                  <span className="text-stone-600">
-                    {new Date(submission.startDate).toLocaleDateString('en-US', {
-                      weekday: 'short',
-                      month: 'short',
-                      day: 'numeric',
-                      year: 'numeric',
-                      hour: 'numeric',
-                      minute: '2-digit',
-                    })}
-                  </span>
+                <div className={submission.additionalDates?.length > 0 ? 'md:col-span-2' : ''}>
+                  {submission.additionalDates?.length > 0 ? (
+                    <>
+                      <span className="font-medium text-stone-700">
+                        Showings ({1 + submission.additionalDates.length}):
+                      </span>
+                      <ul className="mt-1 space-y-0.5">
+                        {[submission.startDate, ...submission.additionalDates].map((d, i) => (
+                          <li key={i} className="text-stone-600">
+                            {new Date(d).toLocaleDateString('en-US', {
+                              weekday: 'short',
+                              month: 'short',
+                              day: 'numeric',
+                              year: 'numeric',
+                              hour: 'numeric',
+                              minute: '2-digit',
+                            })}
+                          </li>
+                        ))}
+                      </ul>
+                    </>
+                  ) : (
+                    <>
+                      <span className="font-medium text-stone-700">Date:</span>{' '}
+                      <span className="text-stone-600">
+                        {new Date(submission.startDate).toLocaleDateString('en-US', {
+                          weekday: 'short',
+                          month: 'short',
+                          day: 'numeric',
+                          year: 'numeric',
+                          hour: 'numeric',
+                          minute: '2-digit',
+                        })}
+                      </span>
+                    </>
+                  )}
                 </div>
                 <div>
                   <span className="font-medium text-stone-700">Venue:</span>{' '}

--- a/src/app/api/admin/submissions/[id]/approve/route.ts
+++ b/src/app/api/admin/submissions/[id]/approve/route.ts
@@ -32,33 +32,37 @@ export async function POST(
       )
     }
 
-    // Create Event from submission
-    const event = await prisma.event.create({
-      data: {
-        title: submission.title,
-        description: submission.description,
-        startDate: submission.startDate,
-        endDate: submission.endDate,
-        venue: submission.venue,
-        address: submission.address,
-        city: submission.city,
-        isNyackProper: true,
-        category: submission.category,
-        price: submission.price,
-        isFree: submission.isFree,
-        isFamilyFriendly: submission.isFamilyFriendly,
-        sourceUrl: submission.sourceUrl || '',
-        sourceName: 'User Submission',
-        imageUrl: submission.imageUrl,
-        isHidden: false,
-        // Recurrence fields
-        isRecurring: submission.isRecurring,
-        recurrenceDays: submission.recurrenceDays,
-        recurrenceEndDate: submission.recurrenceEndDate,
-      },
-    })
+    const sharedEventData = {
+      title: submission.title,
+      description: submission.description,
+      endDate: submission.endDate,
+      venue: submission.venue,
+      address: submission.address,
+      city: submission.city,
+      isNyackProper: true,
+      category: submission.category,
+      price: submission.price,
+      isFree: submission.isFree,
+      isFamilyFriendly: submission.isFamilyFriendly,
+      sourceUrl: submission.sourceUrl || '',
+      sourceName: 'User Submission',
+      imageUrl: submission.imageUrl,
+      isHidden: false,
+      isRecurring: submission.isRecurring,
+      recurrenceDays: submission.recurrenceDays,
+      recurrenceEndDate: submission.recurrenceEndDate,
+    }
 
-    // Update submission status
+    // Create one Event per showing date; primary date first
+    const showingDates = [submission.startDate, ...submission.additionalDates]
+    const createdEvents = await Promise.all(
+      showingDates.map((startDate) =>
+        prisma.event.create({ data: { ...sharedEventData, startDate } })
+      )
+    )
+    const event = createdEvents[0]
+
+    // Update submission status — link to first created event
     await prisma.eventSubmission.update({
       where: { id },
       data: {

--- a/src/app/api/extract-event-from-poster/route.ts
+++ b/src/app/api/extract-event-from-poster/route.ts
@@ -9,9 +9,13 @@ Extract all visible event details and return ONLY valid JSON (no markdown, no ex
 {
   "title": "string - event name",
   "description": "string | null - event description or details",
-  "date": "string | null - date in YYYY-MM-DD format (e.g. 2026-04-15), or null if not found",
-  "startTime": "string | null - start time in HH:MM 24-hour format (e.g. 19:00), or null if not found",
-  "endTime": "string | null - end time in HH:MM 24-hour format, or null if not found",
+  "showings": [
+    {
+      "date": "string - date in YYYY-MM-DD format (e.g. 2026-04-15)",
+      "startTime": "string | null - start time in HH:MM 24-hour format (e.g. 19:00), or null if not found",
+      "endTime": "string | null - end time in HH:MM 24-hour format, or null if not found"
+    }
+  ],
   "venue": "string | null - venue or location name",
   "address": "string | null - street address if visible",
   "city": "string - city name, default to Nyack if not specified",
@@ -24,6 +28,7 @@ Extract all visible event details and return ONLY valid JSON (no markdown, no ex
 
 **Rules:**
 - Today's date is ${new Date().toISOString().split('T')[0]}. If a date is shown without a year, infer the most logical upcoming year.
+- "showings" MUST be an array with at least one entry. If the poster has multiple dates/times (e.g. "May 7 @ 7pm, May 8 @ 7pm, May 9 @ 1pm & 7pm"), list every individual showing as a separate object. A line like "May 9 @ 1pm & 7pm" produces TWO entries (same date, different times).
 - Return ALL fields, using null for anything not found on the poster.
 - For category, make your best guess based on the event type.
 - If the poster shows a QR code or website URL, include it in sourceUrl.
@@ -122,6 +127,15 @@ export async function POST(request: NextRequest) {
         { error: 'Failed to parse AI response' },
         { status: 500 }
       )
+    }
+
+    // Normalise: ensure showings is always an array (handles old single-date responses)
+    if (!Array.isArray(parsed.showings)) {
+      parsed.showings = [{
+        date: parsed.date ?? null,
+        startTime: parsed.startTime ?? null,
+        endTime: parsed.endTime ?? null,
+      }]
     }
 
     return NextResponse.json({ event: parsed })

--- a/src/app/api/submit-event/route.ts
+++ b/src/app/api/submit-event/route.ts
@@ -81,6 +81,16 @@ export async function POST(request: NextRequest) {
       }
     }
 
+    // Parse additional showing dates
+    const additionalDates: Date[] = []
+    if (Array.isArray(data.additionalDates)) {
+      for (const raw of data.additionalDates) {
+        if (typeof raw === 'string' && raw) {
+          additionalDates.push(parseEasternTime(raw))
+        }
+      }
+    }
+
     // Create submission
     const submission = await prisma.eventSubmission.create({
       data: {
@@ -99,6 +109,8 @@ export async function POST(request: NextRequest) {
         imageUrl: data.imageUrl || null,
         submitterEmail: data.submitterEmail,
         status: 'PENDING',
+        // Multiple showings
+        additionalDates,
         // Recurrence fields
         isRecurring: data.isRecurring ?? false,
         recurrenceDays: data.recurrenceDays || [],

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -21,6 +21,12 @@ export default function SubmitEventPage() {
   const [posterFilled, setPosterFilled] = useState(false)
   const posterInputRef = useRef<HTMLInputElement>(null)
 
+  // Multiple showings state
+  const [hasMultipleShowings, setHasMultipleShowings] = useState(false)
+  const [showings, setShowings] = useState<Array<{ date: string; time: string }>>([
+    { date: '', time: '' },
+  ])
+
   // File upload state
   const [uploadMode, setUploadMode] = useState<'url' | 'file'>('url')
   const [selectedFile, setSelectedFile] = useState<File | null>(null)
@@ -95,10 +101,23 @@ export default function SubmitEventPage() {
         }
       }
 
+      // Validate multiple showings
+      if (hasMultipleShowings) {
+        if (showings.some((s) => !s.date || !s.time)) {
+          setError('Please fill in a date and time for every showing')
+          setSaving(false)
+          return
+        }
+      }
+
       // Calculate start date
       let startDateTime: string
+      let additionalDates: string[] = []
 
-      if (formData.isRecurring) {
+      if (hasMultipleShowings) {
+        startDateTime = `${showings[0].date}T${showings[0].time}`
+        additionalDates = showings.slice(1).map((s) => `${s.date}T${s.time}`)
+      } else if (formData.isRecurring) {
         // For recurring events, calculate the next occurrence of the first selected day
         const now = new Date()
         const currentDay = now.getDay()
@@ -149,6 +168,7 @@ export default function SubmitEventPage() {
           ? `${formData.startDate}T${formData.startTime}`
           : `${formData.startDate}T00:00`
       }
+      // additionalDates only populated in hasMultipleShowings branch above
 
       let endDateTime = null
       if (formData.endDate) {
@@ -167,6 +187,7 @@ export default function SubmitEventPage() {
           endDate: formData.isRecurring ? null : endDateTime,
           price: formData.isFree ? null : formData.price || null,
           recurrenceEndDate: formData.recurrenceEndDate || null,
+          additionalDates,
         }),
       })
 
@@ -214,14 +235,19 @@ export default function SubmitEventPage() {
 
       const { event } = await response.json()
 
-      // Fill in form fields with extracted data
+      // showings is always an array (normalised in the API)
+      const showingsData: Array<{ date: string; startTime: string | null; endTime: string | null }> =
+        event.showings ?? []
+
+      // Fill in shared form fields
       setFormData((prev) => ({
         ...prev,
         title: event.title || prev.title,
         description: event.description || prev.description,
-        startDate: event.date || prev.startDate,
-        startTime: event.startTime || prev.startTime,
-        endTime: event.endTime || prev.endTime,
+        // Single-date fields — set from first showing; UI may override via showings UI below
+        startDate: showingsData[0]?.date || prev.startDate,
+        startTime: showingsData[0]?.startTime || prev.startTime,
+        endTime: showingsData[0]?.endTime || prev.endTime,
         venue: event.venue || prev.venue,
         address: event.address || prev.address,
         city: event.city || prev.city,
@@ -231,6 +257,17 @@ export default function SubmitEventPage() {
         category: (event.category as Category) || prev.category,
         sourceUrl: event.sourceUrl || prev.sourceUrl,
       }))
+
+      // If the poster has multiple showings, activate multiple-showings mode
+      if (showingsData.length > 1) {
+        setHasMultipleShowings(true)
+        setShowings(
+          showingsData.map((s) => ({
+            date: s.date ?? '',
+            time: s.startTime ?? '',
+          }))
+        )
+      }
 
       // Use the poster as the event image
       setSelectedFile(file)
@@ -362,6 +399,9 @@ export default function SubmitEventPage() {
                   setSelectedFile(null)
                   setPreviewUrl('')
                   setUploadError('')
+                  // Reset showings state
+                  setHasMultipleShowings(false)
+                  setShowings([{ date: '', time: '' }])
                 }}
                 className="px-6 py-2 bg-stone-100 text-stone-700 rounded-lg font-medium hover:bg-stone-200 transition-colors"
               >
@@ -520,8 +560,8 @@ export default function SubmitEventPage() {
               />
             </div>
 
-            {/* Date and Time */}
-            <div className="grid grid-cols-2 gap-4 mb-4">
+            {/* Date and Time — hidden when multiple showings mode is active */}
+            <div className={`grid grid-cols-2 gap-4 mb-4 ${hasMultipleShowings ? 'hidden' : ''}`}>
               {/* Only show Event Date for one-time events */}
               {!formData.isRecurring && (
                 <div>
@@ -530,7 +570,7 @@ export default function SubmitEventPage() {
                   </label>
                   <input
                     type="date"
-                    required
+                    required={!hasMultipleShowings}
                     value={formData.startDate}
                     onChange={(e) => updateField('startDate', e.target.value)}
                     className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
@@ -543,7 +583,7 @@ export default function SubmitEventPage() {
                 </label>
                 <input
                   type="time"
-                  required
+                  required={!hasMultipleShowings}
                   value={formData.startTime}
                   onChange={(e) => updateField('startTime', e.target.value)}
                   className="w-full px-4 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra"
@@ -551,8 +591,89 @@ export default function SubmitEventPage() {
               </div>
             </div>
 
-            {/* Recurring Event Section */}
-            <div className="mb-4">
+            {/* Multiple Showings Section */}
+            {!formData.isRecurring && (
+              <div className="mb-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <input
+                    type="checkbox"
+                    id="hasMultipleShowings"
+                    checked={hasMultipleShowings}
+                    onChange={(e) => {
+                      setHasMultipleShowings(e.target.checked)
+                      if (e.target.checked) {
+                        // Seed first row from whatever's already in the single-date fields
+                        setShowings([{ date: formData.startDate, time: formData.startTime }])
+                      } else {
+                        setShowings([{ date: '', time: '' }])
+                      }
+                    }}
+                    className="rounded border-stone-300 text-terra focus:ring-terra"
+                  />
+                  <label htmlFor="hasMultipleShowings" className="text-sm font-medium text-stone-700">
+                    This event has multiple showings / dates
+                  </label>
+                </div>
+
+                {hasMultipleShowings && (
+                  <div className="border-l-4 border-terra pl-4 py-3 bg-cream rounded-r-lg space-y-3">
+                    <p className="text-sm text-stone-600">
+                      Add each showing as a separate date and time. Each will be listed individually on the calendar.
+                    </p>
+                    {showings.map((showing, idx) => (
+                      <div key={idx} className="flex items-center gap-2">
+                        <span className="text-xs text-stone-500 w-5 text-right flex-shrink-0">{idx + 1}.</span>
+                        <input
+                          type="date"
+                          value={showing.date}
+                          onChange={(e) => {
+                            const next = [...showings]
+                            next[idx] = { ...next[idx], date: e.target.value }
+                            setShowings(next)
+                          }}
+                          className="flex-1 px-3 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra text-sm"
+                        />
+                        <input
+                          type="time"
+                          value={showing.time}
+                          onChange={(e) => {
+                            const next = [...showings]
+                            next[idx] = { ...next[idx], time: e.target.value }
+                            setShowings(next)
+                          }}
+                          className="flex-1 px-3 py-2 border border-sand rounded-lg focus:outline-none focus:ring-2 focus:ring-terra text-sm"
+                        />
+                        {showings.length > 1 && (
+                          <button
+                            type="button"
+                            onClick={() => setShowings(showings.filter((_, i) => i !== idx))}
+                            className="text-stone-400 hover:text-red-500 transition-colors flex-shrink-0"
+                            aria-label="Remove showing"
+                          >
+                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                          </button>
+                        )}
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() => setShowings([...showings, { date: '', time: '' }])}
+                      className="flex items-center gap-1 text-sm text-terra hover:text-harvest font-medium"
+                    >
+                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      </svg>
+                      Add another showing
+                    </button>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Recurring Event Section — hidden when multiple showings mode is active */}
+            <div className={`mb-4 ${hasMultipleShowings ? 'hidden' : ''}`}>
               <div className="flex items-center gap-2 mb-3">
                 <input
                   type="checkbox"

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -34,91 +34,97 @@ export default function EventCard({ event, showDate = false }: EventCardProps) {
   const categoryLabel = categoryLabels[event.category]
   const categoryColor = getCategoryColor(event.category)
   const title = decodeHtmlEntities(event.title)
+  const isDiscord = event.sourceName === 'Discord'
+
+  const cardClassName = `block rounded-xl border p-4 transition-all ${
+    event.isMarquee
+      ? 'bg-cream border-harvest/30 hover:shadow-md hover:border-harvest/60'
+      : 'bg-surface border-sand hover:shadow-md hover:border-terra/30'
+  }`
+
+  const cardContent = (
+    <div className="flex gap-4">
+      {event.imageUrl ? (
+        <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-oat">
+          <img
+            src={event.imageUrl}
+            alt={title}
+            className="w-full h-full object-cover"
+          />
+        </div>
+      ) : (
+        <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[event.category]}`}>
+          {categoryLucideIcons[event.category]}
+        </div>
+      )}
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="font-display font-semibold text-ink line-clamp-2 leading-tight">
+            {title}
+          </h3>
+          {event.isMarquee && (
+            <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-harvest/20 text-harvest">
+              ★ Big Event
+            </span>
+          )}
+        </div>
+
+        <p className="text-sm text-stone-600 mt-1">
+          {showDate && <span>{formatDate(startDate)} · </span>}
+          {formatTime(startDate)}
+        </p>
+
+        <p className="text-sm text-muted mt-0.5">
+          {event.venue}
+          {event.city !== 'Nyack' && <span> · {event.city}</span>}
+        </p>
+
+        <div className="flex flex-wrap items-center gap-2 mt-2">
+          <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${categoryColor}`}>
+            {categoryLabel}
+          </span>
+
+          {event.isFree ? (
+            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
+              Free
+            </span>
+          ) : event.price ? (
+            <span className="text-xs text-muted">{event.price}</span>
+          ) : null}
+
+          {event.isFamilyFriendly && (
+            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
+              Family
+            </span>
+          )}
+
+          {event.isRecurring && (
+            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">
+              🔁 Recurring
+            </span>
+          )}
+
+          <div onClick={(e) => e.stopPropagation()}>
+            <CalendarDropdown event={event} />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+
+  if (isDiscord) {
+    return <div className={cardClassName}>{cardContent}</div>
+  }
 
   return (
     <Link
       href={event.sourceUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className={`block rounded-xl border p-4 transition-all ${
-        event.isMarquee
-          ? 'bg-cream border-harvest/30 hover:shadow-md hover:border-harvest/60'
-          : 'bg-surface border-sand hover:shadow-md hover:border-terra/30'
-      }`}
+      className={cardClassName}
     >
-      <div className="flex gap-4">
-        {/* Event image or category icon fallback */}
-        {event.imageUrl ? (
-          <div className="w-20 h-20 flex-shrink-0 rounded-lg overflow-hidden bg-oat">
-            <img
-              src={event.imageUrl}
-              alt={title}
-              className="w-full h-full object-cover"
-            />
-          </div>
-        ) : (
-          <div className={`w-20 h-20 flex-shrink-0 rounded-lg flex items-center justify-center ${categoryGradients[event.category]}`}>
-            {categoryLucideIcons[event.category]}
-          </div>
-        )}
-
-        <div className="flex-1 min-w-0">
-          {/* Title */}
-          <div className="flex items-center gap-2">
-            <h3 className="font-display font-semibold text-ink line-clamp-2 leading-tight">
-              {title}
-            </h3>
-            {event.isMarquee && (
-              <span className="flex-shrink-0 px-2 py-0.5 rounded-full text-xs font-semibold bg-harvest/20 text-harvest">
-                ★ Big Event
-              </span>
-            )}
-          </div>
-
-          {/* Time and date */}
-          <p className="text-sm text-stone-600 mt-1">
-            {showDate && <span>{formatDate(startDate)} · </span>}
-            {formatTime(startDate)}
-          </p>
-
-          {/* Venue and location */}
-          <p className="text-sm text-muted mt-0.5">
-            {event.venue}
-            {event.city !== 'Nyack' && <span> · {event.city}</span>}
-          </p>
-
-          {/* Bottom row: category, price, badges */}
-          <div className="flex flex-wrap items-center gap-2 mt-2">
-            <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${categoryColor}`}>
-              {categoryLabel}
-            </span>
-
-            {event.isFree ? (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
-                Free
-              </span>
-            ) : event.price ? (
-              <span className="text-xs text-muted">{event.price}</span>
-            ) : null}
-
-            {event.isFamilyFriendly && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-700">
-                Family
-              </span>
-            )}
-
-            {event.isRecurring && (
-              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-700">
-                🔁 Recurring
-              </span>
-            )}
-
-            <div onClick={(e) => e.stopPropagation()}>
-              <CalendarDropdown event={event} />
-            </div>
-          </div>
-        </div>
-      </div>
+      {cardContent}
     </Link>
   )
 }

--- a/src/lib/discord/processor.ts
+++ b/src/lib/discord/processor.ts
@@ -5,17 +5,36 @@
  */
 
 import { prisma } from '@/lib/db';
+import { put } from '@vercel/blob';
 import { extractEventsFromDiscord } from '../ai/client';
 import { ExtractedEvent } from '../ai/types';
 import { fetchMessagesSince, getDiscordConfig } from './client';
 import { ProcessedDiscordMessage, DiscordMessageData } from './types';
 import {
-  isNyackProper,
   isInCoverageArea,
   parsePrice,
   guessFamilyFriendly,
 } from '../scrapers/utils';
 import { guessCategory } from '../utils/categories';
+
+async function uploadDiscordImageToBlob(discordUrl: string): Promise<string | null> {
+  try {
+    const response = await fetch(discordUrl);
+    if (!response.ok) return null;
+
+    const contentType = response.headers.get('content-type') || 'image/jpeg';
+    if (!contentType.startsWith('image/')) return null;
+
+    const buffer = Buffer.from(await response.arrayBuffer());
+    const ext = contentType.split('/')[1]?.split(';')[0] || 'jpg';
+    const filename = `discord-images/${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`;
+
+    const blob = await put(filename, buffer, { access: 'public', contentType });
+    return blob.url;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Converts AI-extracted event to EventSubmission record
@@ -28,6 +47,7 @@ async function createEventSubmission(
     messageId: string;
     channelName: string;
     authorName: string;
+    attachmentUrls: string[];
   }
 ): Promise<string | null> {
   try {
@@ -72,8 +92,12 @@ async function createEventSubmission(
       extracted.description
     );
 
-    // Use extracted event URL if available, otherwise link to Discord message
     const sourceUrl = extracted.eventUrl || `discord:${messageMetadata.messageId}`;
+
+    // Discord CDN URLs expire, so upload any image to Vercel Blob for permanent storage.
+    // Prefer the AI-identified imageUrl, fall back to the first message attachment.
+    const rawImageUrl = extracted.imageUrl || messageMetadata.attachmentUrls[0] || null;
+    const imageUrl = rawImageUrl ? await uploadDiscordImageToBlob(rawImageUrl) : null;
 
     // Create EventSubmission record
     const submission = await prisma.eventSubmission.create({
@@ -91,7 +115,7 @@ async function createEventSubmission(
         isFamilyFriendly,
         sourceName: 'Discord',
         sourceUrl,
-        imageUrl: extracted.imageUrl ?? null,
+        imageUrl,
         submitterEmail: `discord-${messageMetadata.authorName}@nyack.today`,
         status: 'PENDING',
       },
@@ -151,6 +175,7 @@ async function processDiscordMessage(
         messageId: message.messageId,
         channelName: message.channelName,
         authorName: message.authorName,
+        attachmentUrls: message.attachmentUrls,
       });
 
       if (submissionId) {

--- a/src/lib/scrapers/utils.ts
+++ b/src/lib/scrapers/utils.ts
@@ -532,6 +532,65 @@ export function fixUtcAsEasternDate(date: Date): Date {
 }
 
 /**
+ * Parse one or more showing times from a natural-language date/time string and
+ * return an array of Eastern-time Date objects — one per showing.
+ *
+ * Handles formats like:
+ *   "Thursday, May 7 @ 7pm"          → [Date]
+ *   "Saturday, May 9 @ 1pm & 7pm"    → [Date, Date]
+ *   "Saturday, May 9 @ 1:30pm & 7pm" → [Date, Date]
+ *
+ * Pass `referenceYear` (defaults to current year) when the string has no year.
+ * Returns an empty array if the string cannot be parsed.
+ */
+export function parseShowingDates(line: string, referenceYear?: number): Date[] {
+  const year = referenceYear ?? new Date().getFullYear()
+
+  const MONTHS: Record<string, number> = {
+    january: 0, february: 1, march: 2, april: 3, may: 4, june: 5,
+    july: 6, august: 7, september: 8, october: 9, november: 10, december: 11,
+    jan: 0, feb: 1, mar: 2, apr: 3, jun: 5, jul: 6, aug: 7,
+    sep: 8, oct: 9, nov: 10, dec: 11,
+  }
+
+  // Extract "Month Day" from the line (day-of-week prefix is ignored)
+  const dateMatch = line.match(/([a-z]+)\s+(\d{1,2})(?:,|\s)/i)
+  if (!dateMatch) return []
+
+  const monthStr = dateMatch[1].toLowerCase()
+  const month = MONTHS[monthStr]
+  if (month === undefined) return []
+  const day = parseInt(dateMatch[2], 10)
+
+  // Extract the time portion after "@"
+  const timePart = line.split('@')[1]
+  if (!timePart) return []
+
+  // Split on "&" or "and" to handle multiple times on the same day
+  const timeTokens = timePart.split(/&|\band\b/i).map(t => t.trim()).filter(Boolean)
+
+  const parseTime = (token: string): { hour: number; minute: number } | null => {
+    const m = token.match(/(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i)
+    if (!m) return null
+    let hour = parseInt(m[1], 10)
+    const minute = m[2] ? parseInt(m[2], 10) : 0
+    const meridiem = m[3].toLowerCase()
+    if (meridiem === 'pm' && hour !== 12) hour += 12
+    if (meridiem === 'am' && hour === 12) hour = 0
+    return { hour, minute }
+  }
+
+  const dates: Date[] = []
+  for (const token of timeTokens) {
+    const time = parseTime(token)
+    if (time) {
+      dates.push(makeEasternDate(year, month, day, time.hour, time.minute))
+    }
+  }
+  return dates
+}
+
+/**
  * Fetch a URL with error handling and timeout
  */
 export async function fetchWithTimeout(


### PR DESCRIPTION
## Summary

- **`parseShowingDates()` utility** — parses natural-language date lines like `"May 9 @ 1pm & 7pm"` into individual `Date` objects; any scraper can use this for multi-showing sources
- **Poster scan** — updated AI prompt returns a `showings[]` array so scanning a Stage Left-style poster captures all 8 performances in one shot
- **Submit form** — new \"multiple showings\" mode: checkbox reveals a numbered date/time list with add/remove; auto-activates when the poster scanner finds 2+ dates
- **Schema** — `additionalDates DateTime[]` added to `EventSubmission` (migration: `ALTER TABLE "EventSubmission" ADD COLUMN "additionalDates" TIMESTAMP(3)[] NOT NULL DEFAULT ARRAY[]::TIMESTAMP(3)[]`)
- **Approval** — creates one `Event` per showing date when approving a multi-date submission
- **Admin submissions page** — lists all showings in the card; confirmation dialog names the correct event count (e.g. \"This will create 8 events\")
- **EventCard** — Discord-sourced events render as a `div` instead of a `<Link>` since their `sourceUrl` is a `discord:` pseudo-URL (pre-existing fix)
- **Discord processor** — uploads Discord CDN images to Vercel Blob before saving so they don't expire (pre-existing fix)

## Test plan

- [x] Scan the Stage Left poster → form should switch to multiple-showings mode with all 8 dates pre-populated
- [x] Manually toggle \"multiple showings\", add/remove rows, submit — confirm one `EventSubmission` is created with correct `additionalDates`
- [x] Approve that submission in admin → confirm 8 separate `Event` records are created in the DB
- [x] Admin submissions card shows all showings listed; approve dialog says \"create 8 events\"
- [x] Single-date submission flow unchanged
- [x] Recurring event flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)