### PR TITLE
perf: eliminate client-side waterfall — SSR events, caching, DB cleanup

### DIFF
--- a/prisma/add_composite_index.sql
+++ b/prisma/add_composite_index.sql
@@ -1,0 +1,9 @@
+-- Performance improvement: composite index on the most common query pattern
+-- WHERE isHidden = false AND startDate >= ?
+-- Run with: psql $DATABASE_URL -f prisma/add_composite_index.sql
+-- OR run: npx prisma db push (if using prisma push workflow)
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "Event_isHidden_startDate_idx"
+  ON "Event"("isHidden", "startDate");
+
+SELECT 'Composite index created!' as status;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -73,6 +73,7 @@ model Event {
   @@index([isHidden])
   @@index([isFamilyFriendly])
   @@index([isRecurring])
+  @@index([isHidden, startDate])
 }
 
 // Always-available activities (go-karts, bowling, etc.)

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,323 @@
+'use client'
+
+import { useState, useEffect, useCallback, useRef } from 'react'
+import Header from '@/components/Header'
+import Hero from '@/components/Hero'
+import MarqueeSection from '@/components/MarqueeSection'
+import DateTabs from '@/components/DateTabs'
+import FilterBar, { Filters } from '@/components/FilterBar'
+import EventList from '@/components/EventList'
+import { EventListSkeleton } from '@/components/EventCardSkeleton'
+import BottomNav from '@/components/BottomNav'
+import FallbackBanner from '@/components/FallbackBanner'
+import SubscribeSection from '@/components/SubscribeSection'
+import { DateFilter, formatCustomDatePill } from '@/lib/utils/dates'
+import { Event } from '@prisma/client'
+
+interface EventsApiResponse {
+  events: Event[]
+  pagination: {
+    total: number
+    limit: number
+    offset: number
+    hasMore: boolean
+  }
+}
+
+function convertEventDates(events: Event[]): Event[] {
+  return events.map((event) => ({
+    ...event,
+    startDate: new Date(event.startDate),
+    endDate: event.endDate ? new Date(event.endDate) : null,
+    createdAt: new Date(event.createdAt),
+    updatedAt: new Date(event.updatedAt),
+  }))
+}
+
+function isFallbackDismissed(): boolean {
+  try {
+    return sessionStorage.getItem('tonight-fallback-dismissed') === 'true'
+  } catch {
+    return false
+  }
+}
+
+interface HomeClientProps {
+  initialEvents: Event[]
+  initialDateFilter: DateFilter
+  initialShowFallback: boolean
+  initialMarqueeEvents: Event[]
+}
+
+export default function HomeClient({
+  initialEvents,
+  initialDateFilter,
+  initialShowFallback,
+  initialMarqueeEvents,
+}: HomeClientProps) {
+  const [dateFilter, setDateFilter] = useState<DateFilter>(initialDateFilter)
+  const [customDate, setCustomDate] = useState<Date | null>(null)
+  const [filters, setFilters] = useState<Filters>({
+    category: 'ALL',
+    priceFilter: 'all',
+    location: 'all',
+    familyFriendly: false,
+  })
+  const [events, setEvents] = useState<Event[]>(() => convertEventDates(initialEvents))
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showFallback, setShowFallback] = useState(initialShowFallback)
+  const [marqueeOnly, setMarqueeOnly] = useState(false)
+
+  // Skip the initial fetch — we already have server-rendered data
+  const isInitialMount = useRef(true)
+  const pendingFallbackRef = useRef(false)
+
+  // Server can't read sessionStorage — hide banner if user previously dismissed it
+  useEffect(() => {
+    if (initialShowFallback && isFallbackDismissed()) {
+      setShowFallback(false)
+    }
+  }, [initialShowFallback])
+
+  const buildQueryString = useCallback(() => {
+    const params = new URLSearchParams()
+
+    if (marqueeOnly) {
+      params.set('marquee', 'true')
+      return params.toString()
+    }
+
+    if (customDate) {
+      params.set('date', 'custom')
+      params.set('customDate', customDate.toISOString())
+    } else {
+      params.set('date', dateFilter)
+    }
+
+    if (filters.category !== 'ALL') {
+      params.set('category', filters.category)
+    }
+    if (filters.priceFilter === 'free') {
+      params.set('free', 'true')
+    }
+    if (filters.location === 'nyack') {
+      params.set('nyackOnly', 'true')
+    } else if (filters.location === 'nearby') {
+      params.set('nearbyOnly', 'true')
+    }
+    if (filters.familyFriendly) {
+      params.set('familyFriendly', 'true')
+    }
+
+    return params.toString()
+  }, [dateFilter, filters, customDate, marqueeOnly])
+
+  const fetchEvents = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const queryString = buildQueryString()
+      const response = await fetch(`/api/events?${queryString}`)
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch events')
+      }
+
+      const data: EventsApiResponse = await response.json()
+      const eventsWithDates = convertEventDates(data.events)
+
+      // Tonight is empty → switch to This Week tab and show fallback banner
+      if (
+        dateFilter === 'tonight' &&
+        !customDate &&
+        eventsWithDates.length === 0 &&
+        !isFallbackDismissed()
+      ) {
+        pendingFallbackRef.current = true
+        setDateFilter('week')
+        return
+      }
+
+      if (pendingFallbackRef.current && dateFilter === 'week') {
+        pendingFallbackRef.current = false
+        setShowFallback(true)
+      } else {
+        setShowFallback(false)
+      }
+
+      setEvents(eventsWithDates)
+    } catch (err) {
+      console.error('Error fetching events:', err)
+      setError('Failed to load events. Please try again.')
+      setEvents([])
+      setShowFallback(false)
+    } finally {
+      setLoading(false)
+    }
+  }, [buildQueryString, dateFilter, customDate])
+
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    fetchEvents()
+  }, [fetchEvents])
+
+  const handleShowAllMarquee = useCallback(() => {
+    setMarqueeOnly(true)
+    pendingFallbackRef.current = false
+    setShowFallback(false)
+    setTimeout(() => {
+      document.getElementById('events-section')?.scrollIntoView({ behavior: 'smooth' })
+    }, 50)
+  }, [])
+
+  const handleClearMarquee = () => {
+    setMarqueeOnly(false)
+  }
+
+  const handleDateFilterChange = (filter: DateFilter) => {
+    pendingFallbackRef.current = false
+    setShowFallback(false)
+    setCustomDate(null)
+    setDateFilter(filter)
+    setMarqueeOnly(false)
+  }
+
+  const handleCustomDateSelect = (date: Date) => {
+    setCustomDate(date)
+  }
+
+  const handleCustomDateClear = () => {
+    setCustomDate(null)
+  }
+
+  const handleFallbackDismiss = () => {
+    try {
+      sessionStorage.setItem('tonight-fallback-dismissed', 'true')
+    } catch {
+      // sessionStorage unavailable
+    }
+    setShowFallback(false)
+  }
+
+  const getHeading = () => {
+    if (marqueeOnly) return '⭐ Big Events'
+    if (customDate) {
+      return `Events on ${formatCustomDatePill(customDate)}`
+    }
+    switch (dateFilter) {
+      case 'tonight':
+        return "What's Happening Today"
+      case 'tomorrow':
+        return "Tomorrow's Events"
+      case 'weekend':
+        return 'This Weekend'
+      case 'week':
+        return 'This Week'
+      case 'month':
+        return 'This Month'
+      default:
+        return 'Events'
+    }
+  }
+
+  const getEmptyMessage = () => {
+    if (customDate) {
+      return `No events on ${formatCustomDatePill(customDate)}`
+    }
+    if (dateFilter === 'tonight') {
+      return 'No events tonight'
+    }
+    if (filters.familyFriendly) {
+      return 'No family-friendly events found for this time period'
+    }
+    if (filters.priceFilter === 'free') {
+      return 'No free events found for this time period'
+    }
+    return 'No events found for this time period'
+  }
+
+  return (
+    <div className="min-h-screen">
+      <Header />
+      <Hero />
+
+      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-3 pb-12">
+        <MarqueeSection onShowAll={handleShowAllMarquee} initialEvents={initialMarqueeEvents} />
+
+        <div className="mb-6">
+          <h1 className="font-display font-semibold text-3xl text-ink mb-2">
+            {getHeading()}
+          </h1>
+          <p className="text-muted text-sm">
+            Discover events and activities in Nyack and the surrounding area
+          </p>
+        </div>
+
+        <div className="mb-4">
+          <DateTabs
+            activeFilter={marqueeOnly ? 'custom' : dateFilter}
+            onFilterChange={handleDateFilterChange}
+            customDate={customDate}
+            onCustomDateSelect={handleCustomDateSelect}
+            onCustomDateClear={handleCustomDateClear}
+          />
+        </div>
+
+        <div className="mb-6">
+          <FilterBar filters={filters} onFiltersChange={setFilters} />
+        </div>
+
+        {marqueeOnly && (
+          <div className="mb-4 bg-cream border border-harvest/30 rounded-xl px-4 py-2.5 flex items-center justify-between">
+            <span className="text-sm text-harvest font-medium">Showing all upcoming marquee events</span>
+            <button
+              onClick={handleClearMarquee}
+              className="text-terra hover:text-terra/70 text-sm font-medium"
+            >
+              ✕ Clear
+            </button>
+          </div>
+        )}
+
+        {showFallback && (
+          <FallbackBanner onDismiss={handleFallbackDismiss} />
+        )}
+
+        {error && (
+          <div className="text-center py-8">
+            <p className="text-red-500 mb-4">{error}</p>
+            <button
+              onClick={fetchEvents}
+              className="px-4 py-2 bg-terra text-cream rounded-lg hover:bg-terra/90 transition-colors"
+            >
+              Try Again
+            </button>
+          </div>
+        )}
+
+        {!error && (
+          loading ? (
+            <EventListSkeleton count={5} />
+          ) : (
+            <EventList
+              events={events}
+              showDate={true}
+              emptyMessage={getEmptyMessage()}
+            />
+          )
+        )}
+
+        <div id="subscribe-section" className="mt-10">
+          <SubscribeSection />
+        </div>
+      </main>
+
+      <BottomNav />
+    </div>
+  )
+}

--- a/src/app/api/admin/cleanup/route.ts
+++ b/src/app/api/admin/cleanup/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+/**
+ * POST /api/admin/cleanup
+ * Delete past non-recurring events and old scraper logs to keep the DB lean.
+ *
+ * Body (all optional):
+ * - daysOld: delete events whose startDate is older than this many days (default: 1)
+ * - deleteScraperLogs: also prune scraper logs older than 30 days (default: true)
+ * - dryRun: if true, only count affected rows without deleting (default: false)
+ */
+export async function POST(request: NextRequest) {
+  const adminPassword = process.env.ADMIN_PASSWORD
+  const authHeader = request.headers.get('authorization')
+
+  if (!adminPassword || authHeader !== `Bearer ${adminPassword}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  let body: Record<string, unknown> = {}
+  try {
+    body = await request.json()
+  } catch {
+    // empty body is fine
+  }
+
+  const daysOld = typeof body.daysOld === 'number' ? body.daysOld : 1
+  const deleteScraperLogs = body.deleteScraperLogs !== false
+  const dryRun = body.dryRun === true
+
+  const cutoff = new Date(Date.now() - daysOld * 24 * 60 * 60 * 1000)
+  const logCutoff = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+
+  if (dryRun) {
+    const [eventCount, logCount] = await Promise.all([
+      prisma.event.count({
+        where: { isRecurring: false, startDate: { lt: cutoff } },
+      }),
+      deleteScraperLogs
+        ? prisma.scraperLog.count({ where: { runAt: { lt: logCutoff } } })
+        : Promise.resolve(0),
+    ])
+
+    return NextResponse.json({
+      dryRun: true,
+      wouldDelete: { events: eventCount, scraperLogs: logCount },
+      cutoffDate: cutoff.toISOString(),
+    })
+  }
+
+  const [deletedEvents, deletedLogs] = await Promise.all([
+    prisma.event.deleteMany({
+      where: { isRecurring: false, startDate: { lt: cutoff } },
+    }),
+    deleteScraperLogs
+      ? prisma.scraperLog.deleteMany({ where: { runAt: { lt: logCutoff } } })
+      : Promise.resolve({ count: 0 }),
+  ])
+
+  return NextResponse.json({
+    deleted: {
+      events: deletedEvents.count,
+      scraperLogs: deletedLogs.count,
+    },
+    cutoffDate: cutoff.toISOString(),
+  })
+}

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,37 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Category } from '@prisma/client'
+import { DateFilter } from '@/lib/utils/dates'
+import { queryEvents } from '@/lib/utils/events-query'
 import { prisma } from '@/lib/db'
-import { Category, Event } from '@prisma/client'
-import { getDateRange, getCustomDateRange, DateFilter } from '@/lib/utils/dates'
-import { areEventsDuplicates } from '@/lib/scrapers/utils'
-import { generateRecurringInstances } from '@/lib/utils/recurrence'
-
-/**
- * Deduplicate events using fuzzy matching
- * Keeps the first occurrence of each unique event
- */
-function deduplicateEvents(events: Event[]): Event[] {
-  const deduplicated: Event[] = []
-
-  for (const event of events) {
-    // Check if this event is a duplicate of any already added event
-    const isDuplicate = deduplicated.some(existingEvent =>
-      areEventsDuplicates(
-        event.title,
-        event.venue,
-        event.startDate,
-        existingEvent.title,
-        existingEvent.venue,
-        existingEvent.startDate
-      )
-    )
-
-    if (!isDuplicate) {
-      deduplicated.push(event)
-    }
-  }
-
-  return deduplicated
-}
 
 /**
  * GET /api/events
@@ -51,7 +22,6 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
 
-    // Parse query params
     const dateFilter = searchParams.get('date') as DateFilter | null
     const category = searchParams.get('category') as Category | null
     const free = searchParams.get('free') === 'true'
@@ -62,139 +32,39 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get('limit') || '50', 10)
     const offset = parseInt(searchParams.get('offset') || '0', 10)
 
-    // Build where clause
-    const where: Record<string, unknown> = {
-      isHidden: false,
-    }
-
-    // Date filter
     const customDateParam = searchParams.get('customDate')
-    if (dateFilter === 'custom' && customDateParam) {
-      const customDate = new Date(customDateParam)
-      const { start, end } = getCustomDateRange(customDate)
-      where.startDate = { gte: start, lte: end }
-    } else if (dateFilter && dateFilter !== 'custom') {
-      const { start, end } = getDateRange(dateFilter)
-      where.startDate = { gte: start, lte: end }
-    } else {
-      // Default to future events only
-      where.startDate = { gte: new Date() }
-    }
+    const customDate = dateFilter === 'custom' && customDateParam ? new Date(customDateParam) : null
 
-    // Category filter
-    if (category && Object.values(Category).includes(category)) {
-      where.category = category
-    }
+    const [events, total] = await Promise.all([
+      queryEvents({
+        dateFilter,
+        customDate,
+        category,
+        free,
+        familyFriendly,
+        nyackOnly,
+        nearbyOnly,
+        marqueeOnly,
+        limit,
+        offset,
+      }),
+      prisma.event.count({ where: { isHidden: false } }),
+    ])
 
-    // Free filter
-    if (free) {
-      where.isFree = true
-    }
-
-    // Family-friendly filter
-    if (familyFriendly) {
-      where.isFamilyFriendly = true
-    }
-
-    // Location filters
-    if (nyackOnly) {
-      where.isNyackProper = true
-    } else if (nearbyOnly) {
-      where.isNyackProper = false
-    }
-
-    // Marquee filter
-    if (marqueeOnly) {
-      where.isMarquee = true
-    }
-
-    // Get date range for recurring events query
-    const { start, end } = (() => {
-      if (dateFilter === 'custom' && customDateParam) {
-        return getCustomDateRange(new Date(customDateParam))
-      }
-      if (dateFilter && dateFilter !== 'custom') {
-        return getDateRange(dateFilter)
-      }
-      return { start: new Date(), end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) }
-    })()
-
-    // Fetch one-time events
-    const oneTimeWhere = { ...where, isRecurring: false }
-    const oneTimeEvents = await prisma.event.findMany({
-      where: oneTimeWhere,
-      orderBy: {
-        startDate: 'asc',
-      },
-      take: Math.min(limit, 100), // Cap at 100
-      skip: offset,
-    })
-
-    // Fetch recurring events that might have instances in the date range
-    // Build where clause without the startDate filter from one-time events
-    const { startDate: _ignored, ...baseFilters } = where
-    const recurringEvents = await prisma.event.findMany({
-      where: {
-        ...baseFilters,
-        isRecurring: true,
-        startDate: { lte: end }, // Event started on or before range end
-        OR: [
-          { recurrenceEndDate: { gte: start } }, // Recurrence ends after range start
-          { recurrenceEndDate: null }, // Or no end date (infinite)
-        ],
-      },
-      orderBy: {
-        startDate: 'asc',
-      },
-    })
-
-    // Generate instances for recurring events within the date range
-    const recurringInstances = recurringEvents.flatMap(event => {
-      console.log('Generating instances for recurring event:', {
-        title: event.title,
-        isRecurring: event.isRecurring,
-        recurrenceDays: event.recurrenceDays,
-        startDate: event.startDate,
-        recurrenceEndDate: event.recurrenceEndDate,
-        dateRange: { start, end }
-      })
-      const instances = generateRecurringInstances(event, start, end)
-      console.log(`Generated ${instances.length} instances`)
-      return instances
-    })
-
-    // Combine one-time events and recurring instances
-    const allEvents = [...oneTimeEvents, ...recurringInstances].sort(
-      (a, b) => a.startDate.getTime() - b.startDate.getTime()
-    )
-
-    // Deduplicate events based on title, venue, and date
-    const deduplicatedEvents = deduplicateEvents(allEvents)
-
-    // Get total count for pagination
-    const oneTimeTotal = await prisma.event.count({ where: oneTimeWhere })
-    const recurringTotal = await prisma.event.count({
-      where: {
-        ...baseFilters,
-        isRecurring: true,
-        startDate: { lte: end },
-        OR: [
-          { recurrenceEndDate: { gte: start } },
-          { recurrenceEndDate: null },
-        ],
-      },
-    })
-    const total = oneTimeTotal + recurringTotal
-
-    return NextResponse.json({
-      events: deduplicatedEvents,
+    const response = NextResponse.json({
+      events,
       pagination: {
         total,
         limit,
         offset,
-        hasMore: offset + deduplicatedEvents.length < total,
+        hasMore: offset + events.length < total,
       },
     })
+
+    // Cache for 60 seconds at the CDN, serve stale for up to 5 minutes while revalidating
+    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300')
+
+    return response
   } catch (error) {
     console.error('Events API error:', error)
     const message = error instanceof Error ? error.message : 'Unknown error'

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { Category } from '@prisma/client'
 import { DateFilter } from '@/lib/utils/dates'
 import { queryEvents } from '@/lib/utils/events-query'
-import { prisma } from '@/lib/db'
 
 /**
  * GET /api/events
@@ -35,29 +34,26 @@ export async function GET(request: NextRequest) {
     const customDateParam = searchParams.get('customDate')
     const customDate = dateFilter === 'custom' && customDateParam ? new Date(customDateParam) : null
 
-    const [events, total] = await Promise.all([
-      queryEvents({
-        dateFilter,
-        customDate,
-        category,
-        free,
-        familyFriendly,
-        nyackOnly,
-        nearbyOnly,
-        marqueeOnly,
-        limit,
-        offset,
-      }),
-      prisma.event.count({ where: { isHidden: false } }),
-    ])
+    const events = await queryEvents({
+      dateFilter,
+      customDate,
+      category,
+      free,
+      familyFriendly,
+      nyackOnly,
+      nearbyOnly,
+      marqueeOnly,
+      limit,
+      offset,
+    })
 
     const response = NextResponse.json({
       events,
       pagination: {
-        total,
+        total: offset + events.length,
         limit,
         offset,
-        hasMore: offset + events.length < total,
+        hasMore: events.length === limit,
       },
     })
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,304 +1,36 @@
-'use client'
-
-import { useState, useEffect, useCallback, useRef } from 'react'
-import Header from '@/components/Header'
-import Hero from '@/components/Hero'
-import MarqueeSection from '@/components/MarqueeSection'
-import DateTabs from '@/components/DateTabs'
-import FilterBar, { Filters } from '@/components/FilterBar'
-import EventList from '@/components/EventList'
-import { EventListSkeleton } from '@/components/EventCardSkeleton'
-import BottomNav from '@/components/BottomNav'
-import FallbackBanner from '@/components/FallbackBanner'
-import SubscribeSection from '@/components/SubscribeSection'
-import { DateFilter, formatCustomDatePill } from '@/lib/utils/dates'
+import HomeClient from './HomeClient'
+import { queryEvents } from '@/lib/utils/events-query'
 import { Event } from '@prisma/client'
+import { DateFilter } from '@/lib/utils/dates'
 
-interface EventsApiResponse {
-  events: Event[]
-  pagination: {
-    total: number
-    limit: number
-    offset: number
-    hasMore: boolean
+export default async function Home() {
+  // Fetch tonight's events and marquee events in parallel on the server
+  const [tonightEvents, marqueeEvents] = await Promise.all([
+    queryEvents({ dateFilter: 'tonight' }).catch((): Event[] => []),
+    queryEvents({ marqueeOnly: true, limit: 9 }).catch((): Event[] => []),
+  ])
+
+  // Mirror the client-side fallback: if tonight is empty, show this week instead
+  let initialEvents: Event[]
+  let initialDateFilter: DateFilter
+  let initialShowFallback: boolean
+
+  if (tonightEvents.length === 0) {
+    initialEvents = await queryEvents({ dateFilter: 'week' }).catch((): Event[] => [])
+    initialDateFilter = 'week'
+    initialShowFallback = true
+  } else {
+    initialEvents = tonightEvents
+    initialDateFilter = 'tonight'
+    initialShowFallback = false
   }
-}
-
-function convertEventDates(events: Event[]): Event[] {
-  return events.map((event) => ({
-    ...event,
-    startDate: new Date(event.startDate),
-    endDate: event.endDate ? new Date(event.endDate) : null,
-    createdAt: new Date(event.createdAt),
-    updatedAt: new Date(event.updatedAt),
-  }))
-}
-
-function isFallbackDismissed(): boolean {
-  try {
-    return sessionStorage.getItem('tonight-fallback-dismissed') === 'true'
-  } catch {
-    return false
-  }
-}
-
-export default function Home() {
-  const [dateFilter, setDateFilter] = useState<DateFilter>('tonight')
-  const [customDate, setCustomDate] = useState<Date | null>(null)
-  const [filters, setFilters] = useState<Filters>({
-    category: 'ALL',
-    priceFilter: 'all',
-    location: 'all',
-    familyFriendly: false,
-  })
-  const [events, setEvents] = useState<Event[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [showFallback, setShowFallback] = useState(false)
-  const [marqueeOnly, setMarqueeOnly] = useState(false)
-
-  // Signals that the next 'week' fetch was triggered by tonight being empty
-  const pendingFallbackRef = useRef(false)
-
-  const buildQueryString = useCallback(() => {
-    const params = new URLSearchParams()
-
-    if (marqueeOnly) {
-      params.set('marquee', 'true')
-      // No date param → API defaults to all future events
-      return params.toString()
-    }
-
-    if (customDate) {
-      params.set('date', 'custom')
-      params.set('customDate', customDate.toISOString())
-    } else {
-      params.set('date', dateFilter)
-    }
-
-    if (filters.category !== 'ALL') {
-      params.set('category', filters.category)
-    }
-    if (filters.priceFilter === 'free') {
-      params.set('free', 'true')
-    }
-    if (filters.location === 'nyack') {
-      params.set('nyackOnly', 'true')
-    } else if (filters.location === 'nearby') {
-      params.set('nearbyOnly', 'true')
-    }
-    if (filters.familyFriendly) {
-      params.set('familyFriendly', 'true')
-    }
-
-    return params.toString()
-  }, [dateFilter, filters, customDate, marqueeOnly])
-
-  const fetchEvents = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-
-    try {
-      const queryString = buildQueryString()
-      const response = await fetch(`/api/events?${queryString}`)
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch events')
-      }
-
-      const data: EventsApiResponse = await response.json()
-      const eventsWithDates = convertEventDates(data.events)
-
-      // Tonight is empty → switch to This Week tab and show fallback banner
-      if (
-        dateFilter === 'tonight' &&
-        !customDate &&
-        eventsWithDates.length === 0 &&
-        !isFallbackDismissed()
-      ) {
-        pendingFallbackRef.current = true
-        setDateFilter('week')
-        return // re-fetch will be triggered by dateFilter change
-      }
-
-      // If this fetch was the result of a fallback from tonight, show the banner
-      if (pendingFallbackRef.current && dateFilter === 'week') {
-        pendingFallbackRef.current = false
-        setShowFallback(true)
-      } else {
-        setShowFallback(false)
-      }
-
-      setEvents(eventsWithDates)
-    } catch (err) {
-      console.error('Error fetching events:', err)
-      setError('Failed to load events. Please try again.')
-      setEvents([])
-      setShowFallback(false)
-    } finally {
-      setLoading(false)
-    }
-  }, [buildQueryString, dateFilter, customDate])
-
-  useEffect(() => {
-    fetchEvents()
-  }, [fetchEvents])
-
-  const handleShowAllMarquee = useCallback(() => {
-    setMarqueeOnly(true)
-    pendingFallbackRef.current = false
-    setShowFallback(false)
-    setTimeout(() => {
-      document.getElementById('events-section')?.scrollIntoView({ behavior: 'smooth' })
-    }, 50)
-  }, [])
-
-  const handleClearMarquee = () => {
-    setMarqueeOnly(false)
-  }
-
-  const handleDateFilterChange = (filter: DateFilter) => {
-    pendingFallbackRef.current = false
-    setShowFallback(false)
-    setCustomDate(null)
-    setDateFilter(filter)
-    setMarqueeOnly(false)
-  }
-
-  const handleCustomDateSelect = (date: Date) => {
-    setCustomDate(date)
-  }
-
-  const handleCustomDateClear = () => {
-    setCustomDate(null)
-  }
-
-  const handleFallbackDismiss = () => {
-    try {
-      sessionStorage.setItem('tonight-fallback-dismissed', 'true')
-    } catch {
-      // sessionStorage unavailable
-    }
-    setShowFallback(false)
-    // Stay on This Week tab — events remain as-is
-  }
-
-  const getHeading = () => {
-    if (marqueeOnly) return '⭐ Big Events'
-    if (customDate) {
-      return `Events on ${formatCustomDatePill(customDate)}`
-    }
-    switch (dateFilter) {
-      case 'tonight':
-        return "What's Happening Today"
-      case 'tomorrow':
-        return "Tomorrow's Events"
-      case 'weekend':
-        return 'This Weekend'
-      case 'week':
-        return 'This Week'
-      case 'month':
-        return 'This Month'
-      default:
-        return 'Events'
-    }
-  }
-
-  const getEmptyMessage = () => {
-    if (customDate) {
-      return `No events on ${formatCustomDatePill(customDate)}`
-    }
-    if (dateFilter === 'tonight') {
-      return 'No events tonight'
-    }
-    if (filters.familyFriendly) {
-      return 'No family-friendly events found for this time period'
-    }
-    if (filters.priceFilter === 'free') {
-      return 'No free events found for this time period'
-    }
-    return 'No events found for this time period'
-  }
-
-  const showDate = true
 
   return (
-    <div className="min-h-screen">
-      <Header />
-      <Hero />
-
-      <main id="events-section" className="max-w-4xl mx-auto px-4 pt-3 pb-12">
-        <MarqueeSection onShowAll={handleShowAllMarquee} />
-
-        <div className="mb-6">
-          <h1 className="font-display font-semibold text-3xl text-ink mb-2">
-            {getHeading()}
-          </h1>
-          <p className="text-muted text-sm">
-            Discover events and activities in Nyack and the surrounding area
-          </p>
-        </div>
-
-        <div className="mb-4">
-          <DateTabs
-            activeFilter={marqueeOnly ? 'custom' : dateFilter}
-            onFilterChange={handleDateFilterChange}
-            customDate={customDate}
-            onCustomDateSelect={handleCustomDateSelect}
-            onCustomDateClear={handleCustomDateClear}
-          />
-        </div>
-
-        <div className="mb-6">
-          <FilterBar filters={filters} onFiltersChange={setFilters} />
-        </div>
-
-        {marqueeOnly && (
-          <div className="mb-4 bg-cream border border-harvest/30 rounded-xl px-4 py-2.5 flex items-center justify-between">
-            <span className="text-sm text-harvest font-medium">Showing all upcoming marquee events</span>
-            <button
-              onClick={handleClearMarquee}
-              className="text-terra hover:text-terra/70 text-sm font-medium"
-            >
-              ✕ Clear
-            </button>
-          </div>
-        )}
-
-        {showFallback && (
-          <FallbackBanner onDismiss={handleFallbackDismiss} />
-        )}
-
-        {error && (
-          <div className="text-center py-8">
-            <p className="text-red-500 mb-4">{error}</p>
-            <button
-              onClick={fetchEvents}
-              className="px-4 py-2 bg-terra text-cream rounded-lg hover:bg-terra/90 transition-colors"
-            >
-              Try Again
-            </button>
-          </div>
-        )}
-
-        {!error && (
-          loading ? (
-            <EventListSkeleton count={5} />
-          ) : (
-            <EventList
-              events={events}
-              showDate={showDate}
-              emptyMessage={getEmptyMessage()}
-            />
-          )
-        )}
-
-        <div id="subscribe-section" className="mt-10">
-          <SubscribeSection />
-        </div>
-      </main>
-
-      <BottomNav />
-    </div>
+    <HomeClient
+      initialEvents={initialEvents}
+      initialDateFilter={initialDateFilter}
+      initialShowFallback={initialShowFallback}
+      initialMarqueeEvents={marqueeEvents}
+    />
   )
 }

--- a/src/components/MarqueeSection.tsx
+++ b/src/components/MarqueeSection.tsx
@@ -28,6 +28,7 @@ const categoryLucideIcons: Record<Category, React.ReactNode> = {
 
 interface MarqueeSectionProps {
   onShowAll: () => void
+  initialEvents?: Event[]
 }
 
 function convertDates(events: Event[]): Event[] {
@@ -40,13 +41,18 @@ function convertDates(events: Event[]): Event[] {
   }))
 }
 
-export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
-  const [events, setEvents] = useState<Event[]>([])
+export default function MarqueeSection({ onShowAll, initialEvents }: MarqueeSectionProps) {
+  const [events, setEvents] = useState<Event[]>(() =>
+    initialEvents ? convertDates(initialEvents) : []
+  )
   const [atStart, setAtStart] = useState(true)
-  const [atEnd, setAtEnd] = useState(false)
+  const [atEnd, setAtEnd] = useState(() => !initialEvents || initialEvents.length <= 3)
   const scrollRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
+    // Skip the fetch if we already have server-rendered data
+    if (initialEvents && initialEvents.length > 0) return
+
     fetch('/api/events?marquee=true&limit=9')
       .then((r) => r.json())
       .then((data) => {
@@ -55,7 +61,7 @@ export default function MarqueeSection({ onShowAll }: MarqueeSectionProps) {
         setAtEnd(evts.length <= 3)
       })
       .catch(() => {})
-  }, [])
+  }, [initialEvents])
 
   const updateArrows = useCallback(() => {
     const el = scrollRef.current

--- a/src/lib/utils/events-query.ts
+++ b/src/lib/utils/events-query.ts
@@ -1,0 +1,103 @@
+import { prisma } from '@/lib/db'
+import { Category, Event } from '@prisma/client'
+import { getDateRange, getCustomDateRange, DateFilter } from '@/lib/utils/dates'
+import { areEventsDuplicates } from '@/lib/scrapers/utils'
+import { generateRecurringInstances } from '@/lib/utils/recurrence'
+
+export interface EventQueryOptions {
+  dateFilter?: DateFilter | null
+  customDate?: Date | null
+  category?: Category | null
+  free?: boolean
+  familyFriendly?: boolean
+  nyackOnly?: boolean
+  nearbyOnly?: boolean
+  marqueeOnly?: boolean
+  limit?: number
+  offset?: number
+}
+
+function deduplicateEvents(events: Event[]): Event[] {
+  const deduplicated: Event[] = []
+  for (const event of events) {
+    const isDuplicate = deduplicated.some(existing =>
+      areEventsDuplicates(
+        event.title, event.venue, event.startDate,
+        existing.title, existing.venue, existing.startDate,
+      )
+    )
+    if (!isDuplicate) deduplicated.push(event)
+  }
+  return deduplicated
+}
+
+export async function queryEvents(options: EventQueryOptions = {}): Promise<Event[]> {
+  const {
+    dateFilter,
+    customDate,
+    category,
+    free,
+    familyFriendly,
+    nyackOnly,
+    nearbyOnly,
+    marqueeOnly,
+    limit = 50,
+    offset = 0,
+  } = options
+
+  const where: Record<string, unknown> = { isHidden: false }
+
+  const { start, end } = (() => {
+    if (dateFilter === 'custom' && customDate) return getCustomDateRange(customDate)
+    if (dateFilter && dateFilter !== 'custom') return getDateRange(dateFilter)
+    return { start: new Date(), end: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000) }
+  })()
+
+  if (dateFilter === 'custom' && customDate) {
+    where.startDate = { gte: start, lte: end }
+  } else if (dateFilter && dateFilter !== 'custom') {
+    where.startDate = { gte: start, lte: end }
+  } else {
+    where.startDate = { gte: new Date() }
+  }
+
+  if (category && Object.values(Category).includes(category)) where.category = category
+  if (free) where.isFree = true
+  if (familyFriendly) where.isFamilyFriendly = true
+  if (nyackOnly) where.isNyackProper = true
+  else if (nearbyOnly) where.isNyackProper = false
+  if (marqueeOnly) where.isMarquee = true
+
+  const { startDate: _ignored, ...baseFilters } = where
+
+  const [oneTimeEvents, recurringEvents] = await Promise.all([
+    prisma.event.findMany({
+      where: { ...where, isRecurring: false },
+      orderBy: { startDate: 'asc' },
+      take: Math.min(limit, 100),
+      skip: offset,
+    }),
+    prisma.event.findMany({
+      where: {
+        ...baseFilters,
+        isRecurring: true,
+        startDate: { lte: end },
+        OR: [
+          { recurrenceEndDate: { gte: start } },
+          { recurrenceEndDate: null },
+        ],
+      },
+      orderBy: { startDate: 'asc' },
+    }),
+  ])
+
+  const recurringInstances = recurringEvents.flatMap(event =>
+    generateRecurringInstances(event, start, end)
+  )
+
+  return deduplicateEvents(
+    [...oneTimeEvents, ...recurringInstances].sort(
+      (a, b) => a.startDate.getTime() - b.startDate.getTime()
+    )
+  )
+}


### PR DESCRIPTION
Fixes #80

**Root cause**: The main page was a fully client-side component that fetched events via API in useEffect, causing a 2-3s delay before events appeared. MarqueeSection added a second separate API call.

**Changes**:
- Convert page.tsx to a React Server Component — events pre-fetched on server so HTML arrives with events already in it
- Extract HomeClient.tsx for all interactive state
- Pass initial marquee events server-side, eliminating second API call
- Shared queryEvents utility with parallelized DB queries
- Cache-Control headers on events API for CDN caching
- Composite DB index on (isHidden, startDate)
- Admin cleanup endpoint for flushing past events

Generated with [Claude Code](https://claude.ai/code)