### PR TITLE
fix: add GET handler to digest route so Vercel cron can trigger it

### DIFF
--- a/src/app/api/digest/route.ts
+++ b/src/app/api/digest/route.ts
@@ -44,7 +44,7 @@ function buildWeekLabel(start: Date, end: Date): string {
   return `${fmt(start)} – ${fmt(end)}`
 }
 
-export async function POST(request: NextRequest) {
+function checkAuth(request: NextRequest): boolean {
   const adminPassword = request.headers.get('x-admin-password')
   const cronHeader = request.headers.get('authorization')
 
@@ -55,9 +55,25 @@ export async function POST(request: NextRequest) {
     Boolean(process.env.DIGEST_CRON_SECRET) &&
     cronHeader === `Bearer ${process.env.DIGEST_CRON_SECRET}`
 
-  if (!hasValidAdmin && !hasValidCron) {
+  return hasValidAdmin || hasValidCron
+}
+
+// GET is called by Vercel cron jobs
+export async function GET(request: NextRequest) {
+  if (!checkAuth(request)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
+  return sendDigest(request)
+}
+
+export async function POST(request: NextRequest) {
+  if (!checkAuth(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return sendDigest(request)
+}
+
+async function sendDigest(_request: NextRequest) {
 
   const apiKey = process.env.RESEND_API_KEY
   if (!apiKey) {


### PR DESCRIPTION
## Summary

- Vercel cron jobs make **GET requests**, but `/api/digest` only exported a `POST` handler — causing the Thursday weekly digest to silently return 405 every week and never send
- Extracts auth logic into a shared `checkAuth()` helper and the send logic into `sendDigest()`
- Both `GET` (used by the Vercel cron) and `POST` (used by the admin manual trigger) now work correctly

## Test plan

- [ ] Confirm the Vercel cron at `0 14 * * 4` successfully calls `GET /api/digest` after deploy
- [x] Verify `DIGEST_CRON_SECRET` and `RESEND_API_KEY` are set in Vercel production environment variables
- [ ] Manual admin trigger via `POST /api/digest` (with `x-admin-password` header) still works
- [ ] Subscribers receive the Thursday digest email

🤖 Generated with [Claude Code](https://claude.ai/code)