### PR TITLE
fix: force dynamic rendering on home page to prevent stale date caching

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@ import { queryEvents } from '@/lib/utils/events-query'
 import { Event } from '@prisma/client'
 import { DateFilter } from '@/lib/utils/dates'
 
+export const dynamic = 'force-dynamic'
+
 export default async function Home() {
   // Fetch tonight's events and marquee events in parallel on the server
   const [tonightEvents, marqueeEvents] = await Promise.all([


### PR DESCRIPTION
Without this, Next.js statically renders the page at build time, freezing
the "tonight" date boundaries to the deployment date.

https://claude.ai/code/session_01DK1dH3MTpfx2MhjYmzr57w