### PR TITLE
iOS app backend foundations + admin auth fix

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "nyack-web",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/docs/ios-app-setup.md
+++ b/docs/ios-app-setup.md
@@ -1,0 +1,199 @@
+# Nyack iOS app — scaffolding guide (separate `nyack-app` repo)
+
+The app is a standalone Expo project that consumes the Nyack Today public API
+(see [public-api.md](public-api.md)). It lives in its own repo, not in this one.
+
+Prereqs: Node 18+, an Apple Developer account ($99/yr, needed for push + App
+Store), and the Expo tooling (`npm i -g eas-cli`). Use a physical iPhone for
+push testing (the simulator can't receive remote push).
+
+---
+
+## 1. Create the project
+
+```bash
+cd ~/Development
+npx create-expo-app@latest nyack-app   # pick the "Navigation (TypeScript)" template
+cd nyack-app
+git init && git add -A && git commit -m "chore: bootstrap expo app"
+```
+
+This gives you expo-router (file-based routing), TypeScript, and a tab layout.
+
+## 2. Install dependencies
+
+```bash
+# data + state
+npx expo install @tanstack/react-query @react-native-async-storage/async-storage
+npm install @tanstack/query-async-storage-persister @tanstack/react-query-persist-client zustand
+# native capabilities
+npx expo install expo-notifications expo-device expo-constants expo-linking expo-calendar
+```
+
+## 3. Configure `app.json` (scheme, notifications, EAS)
+
+Set the deep-link scheme to `nyacktoday` so push payloads
+(`nyacktoday://event/<id>`, which `/api/push/tonight` already sends) open the
+right screen:
+
+```jsonc
+{
+  "expo": {
+    "name": "Nyack",
+    "slug": "nyack-app",
+    "scheme": "nyacktoday",
+    "ios": {
+      "bundleIdentifier": "today.nyack.app",
+      "supportsTablet": false,
+      "infoPlist": { "UIBackgroundModes": ["remote-notification"] }
+    },
+    "plugins": ["expo-notifications"]
+  }
+}
+```
+
+## 4. API client (points at production)
+
+`src/api/client.ts`:
+
+```ts
+// Native apps aren't subject to browser CORS, so we call the API directly.
+const BASE_URL = 'https://nyacktoday.com'
+
+export async function apiGet<T>(path: string): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`)
+  if (!res.ok) throw new Error(`GET ${path} -> ${res.status}`)
+  return res.json()
+}
+```
+
+`src/types/api.ts` — hand-mirror the JSON shape (keep it in sync with the
+frozen contract; dates arrive as ISO strings):
+
+```ts
+export type Category =
+  | 'MUSIC' | 'COMEDY' | 'MOVIES' | 'THEATER' | 'FAMILY_KIDS' | 'FOOD_DRINK'
+  | 'SPORTS_RECREATION' | 'COMMUNITY_GOVERNMENT' | 'ART_GALLERIES'
+  | 'CLASSES_WORKSHOPS' | 'OTHER'
+
+export interface EventDTO {
+  id: string            // opaque; recurring occurrences look like `${id}-YYYY-MM-DD`
+  title: string
+  description: string | null
+  startDate: string     // ISO
+  endDate: string | null
+  venue: string
+  address: string | null
+  city: string
+  isNyackProper: boolean
+  category: Category
+  price: string | null
+  isFree: boolean
+  isFamilyFriendly: boolean
+  sourceUrl: string
+  imageUrl: string | null
+  isMarquee: boolean
+}
+
+export interface EventsResponse {
+  events: EventDTO[]
+  pagination: { total: number; limit: number; offset: number; hasMore: boolean }
+}
+```
+
+`src/api/events.ts`:
+
+```ts
+import { apiGet } from './client'
+import type { EventDTO, EventsResponse } from '../types/api'
+
+export const fetchEvents = (qs = '') =>
+  apiGet<EventsResponse>(`/api/events${qs ? `?${qs}` : ''}`)
+
+export const fetchEvent = (id: string) =>
+  apiGet<{ event: EventDTO }>(`/api/events/${encodeURIComponent(id)}`).then((r) => r.event)
+```
+
+## 5. TanStack Query with offline persistence
+
+In the root `app/_layout.tsx`, wrap the app in a `PersistQueryClientProvider`
+backed by AsyncStorage (`staleTime: 60_000` to match the API's cache headers) so
+the app opens instantly with the last-known events.
+
+## 6. Screens (expo-router)
+
+```
+app/
+  _layout.tsx            # QueryClient + persistence + notification handlers
+  (tabs)/_layout.tsx     # Today / Browse / Saved tabs
+  (tabs)/index.tsx       # Today — fetchEvents('date=tonight')
+  (tabs)/browse.tsx      # filters mapped to /api/events params + free-text search
+  (tabs)/saved.tsx       # device-local favorites (Zustand + AsyncStorage)
+  event/[id].tsx         # detail via fetchEvent(id); add-to-calendar + share
+```
+
+Favorites store (`src/stores/favorites.ts`): a Zustand store of event **ids**
+persisted to AsyncStorage. Key on the opaque id from the API; when opening a
+saved event, if `fetchEvent` 404s (a recurring schedule changed), show
+"event updated or removed" instead of crashing.
+
+## 7. Push registration (against `/api/devices`)
+
+`src/push/register.ts`:
+
+```ts
+import * as Notifications from 'expo-notifications'
+import * as Device from 'expo-device'
+import Constants from 'expo-constants'
+
+const BASE_URL = 'https://nyacktoday.com'
+
+export async function registerForPush() {
+  if (!Device.isDevice) return
+  const { status } = await Notifications.requestPermissionsAsync()
+  if (status !== 'granted') return
+
+  const projectId = Constants.expoConfig?.extra?.eas?.projectId
+  const token = (await Notifications.getExpoPushTokenAsync({ projectId })).data // ExponentPushToken[...]
+
+  await fetch(`${BASE_URL}/api/devices`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ expoPushToken: token, platform: 'ios' }),
+  })
+}
+```
+
+Handle taps in `_layout.tsx`: read `response.notification.request.content.data.url`
+(e.g. `nyacktoday://event/<id>`) and route to it via `expo-linking` / expo-router.
+Call `PATCH /api/devices` when the user toggles notification prefs;
+`DELETE /api/devices` if they turn everything off.
+
+## 8. EAS build + push credentials
+
+```bash
+eas login
+eas build:configure          # writes eas.json (development / preview / production)
+eas credentials              # let Expo create/upload the APNs key (one time)
+eas build --profile development --platform ios   # dev client for on-device testing
+```
+
+Then install the dev-client build on your iPhone, run `npx expo start --dev-client`,
+grant notification permission, and confirm the token reaches `/api/devices`.
+
+## 9. Verify end-to-end
+
+- Today/Browse/detail render against production `/api/events`.
+- Kill Wi-Fi → app still opens with persisted events (offline).
+- Fire a test push: `POST /api/push/tonight` with `x-admin-password` (or wait for
+  the 21:00 UTC cron) and confirm the notification arrives and its tap deep-links
+  to the event detail screen.
+- Favorites survive an app restart; a stale favorited id degrades gracefully.
+
+---
+
+### Deferred until the app exists (backend follow-ups)
+- `public/.well-known/apple-app-site-association` for universal links — needs the
+  Apple Team ID + `bundleIdentifier` above.
+- The home-screen "Tonight in Nyack" widget (Phase 1b) — native WidgetKit via
+  `@bacons/apple-targets`; real Swift, EAS Build only.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -1,0 +1,83 @@
+# Public API contract (iOS app + external clients)
+
+These endpoints are consumed by the Nyack iOS app and are a **stable, append-only
+contract**. Installed app versions call them for years, so:
+
+- **Never rename or repurpose** an existing query param or response field.
+- **Never change** the meaning of an existing value (e.g. `date=tonight`).
+- Add capability via **new params or new endpoints**, never by mutating these.
+- Treat every event `id` as **opaque** (see stable ids below).
+
+All responses set `Cache-Control: public, s-maxage=60, stale-while-revalidate=300`.
+
+---
+
+## `GET /api/events`
+
+List events. Recurring events are expanded into per-occurrence instances.
+
+| Param | Values | Meaning |
+|---|---|---|
+| `date` | `tonight` \| `tomorrow` \| `weekend` \| `week` \| `custom` | Date window. Omit for the default ~30-day upcoming window. |
+| `customDate` | ISO date | Only with `date=custom`. |
+| `category` | `Category` enum | Filter to one category. |
+| `free` | `true` | Free events only. |
+| `familyFriendly` | `true` | Family-friendly only. |
+| `nyackOnly` | `true` | Nyack-proper only. |
+| `nearbyOnly` | `true` | Non-Nyack only. |
+| `marquee` | `true` | Featured/marquee events only. |
+| `limit` | int (default 50, one-time cap 100) | Page size. |
+| `offset` | int (default 0) | Pagination offset. |
+
+Response:
+
+```json
+{
+  "events": [ /* Event objects */ ],
+  "pagination": { "total": 0, "limit": 50, "offset": 0, "hasMore": true }
+}
+```
+
+Note: `pagination.total` is `offset + events.length` (not a true count) and
+`hasMore` is heuristic. Clients should paginate by advancing `offset` until a
+short page is returned.
+
+## `GET /api/events/[id]`
+
+Single event by its stable id. Returns `{ "event": Event }` or `404`.
+
+## `GET /api/activities`
+
+Always-available activities directory. Param `category` (or `ALL`). Returns
+`{ "activities": [ /* Activity objects */ ] }`.
+
+---
+
+## Stable event ids
+
+The `id` on every event is opaque and comes in two shapes:
+
+- **One-time event** — the Prisma cuid, e.g. `cmqs0ncrt0008l2042hg5pbvv`.
+- **Recurring occurrence** — `${parentId}-${YYYY-MM-DD}`, e.g.
+  `cmqs...-2026-07-21`. The date suffix is the occurrence's **UTC** date.
+
+Both resolve via `GET /api/events/[id]`. The app keys favorites and deep links
+on this id. If a recurring event's schedule later changes, a previously-saved
+occurrence id may stop resolving (returns 404) — clients must degrade
+gracefully (show "event updated or removed"), never crash.
+
+Parse/format logic lives in one place: `getEventByStableId` in
+`src/lib/utils/events-query.ts` and the id synthesis in
+`src/lib/utils/recurrence.ts`. Keep them in sync.
+
+---
+
+## Push notifications (device-facing)
+
+- `POST /api/devices` — register/refresh a device (idempotent upsert on
+  `expoPushToken`). `PATCH` updates notification prefs; `DELETE` deactivates.
+- Push payloads include `data.url` as a deep link, e.g.
+  `nyacktoday://event/<stableId>`.
+
+Cron/admin-only (not for the app): `POST /api/push/tonight` (also a daily Vercel
+cron), `POST /api/push/send` (admin ad-hoc, `x-admin-password`).

--- a/ios-app-prd.md
+++ b/ios-app-prd.md
@@ -1,0 +1,215 @@
+# Nyack Today iOS App — PRD & Engineering Spec
+**Scope:** Phase 0 (Foundations) + Phase 1 (MVP: Events + "Tonight in Nyack" push)
+**Status:** Draft for agent handoff (Claude Fable 5)
+**Owner:** Danny
+**Last updated:** 2026-07-17
+
+> Phases 2–4 (News/Alerts, Utilities, Dining/Business) are intentionally not specced here — see Appendix A. Don't let an agent start on them; scope creep here is the main risk to shipping the MVP.
+
+---
+
+## 1. Why this exists
+
+Nyack Today (web) already aggregates events from 16+ sources into a "tonight-first" public API. It has no daily presence on a resident's phone — people visit it when planning a weekend, not every day. The iOS app's job is to become the thing every Nyack resident opens daily, starting with the data that already exists (events) and the one feature most likely to drive that daily habit: a **"Tonight in Nyack" push notification**.
+
+Events are the reason people download the app. The notification is the reason they keep it.
+
+## 2. Users & success criteria
+
+**User:** A Nyack resident with an iPhone who currently either doesn't know what's happening locally or checks the website inconsistently.
+
+**MVP success bar** (this is a personal/tester build, not an App Store launch yet):
+- You and a handful of local testers have the app installed via TestFlight and use it without you manually walking them through bugs.
+- The Tonight push fires correctly every day, on time, with the right event, and tapping it opens the right event detail screen.
+- Favorites persist across app restarts and airplane-mode/offline launches.
+- Nothing in the existing website or its public API breaks because of backend changes made to support the app.
+
+**Explicitly not success criteria yet:** app store approval, non-tester adoption, monetization, Android.
+
+## 3. Non-goals for this spec (do not build)
+
+- No user accounts / sign-in (device-local personalization only — see §5).
+- No community/UGC feed.
+- No News/Alerts, Utilities, or Dining/Business features (Phases 2–4, deferred).
+- No Android build (Expo makes it possible later; not now).
+- No monetization code of any kind.
+- No Widget/WidgetKit work in this spec — that's Phase 1b, follow-on, and is the one part of this project that is real native Swift. Do not let an agent bundle it into Phase 1 "since it's related."
+
+If an agent proposes work outside this list, that's a signal to stop and re-scope, not to let it "add value."
+
+## 4. Decisions already made (do not relitigate)
+
+| Decision | Rationale |
+|---|---|
+| Expo (managed workflow) / React Native, not native Swift | Reuses TypeScript/Next.js skills; cross-platform for later Android |
+| No accounts in MVP; favorites/prefs stored device-local (AsyncStorage + Zustand) | Avoids Sign-in-with-Apple requirement and all PII burden |
+| Push via Expo's push service (ExponentPushToken), not raw APNs | Expo manages the APNs key; `expo-server-sdk` handles chunking/receipts |
+| TanStack Query + AsyncStorage persister for server data | App opens instantly with last-known events; offline support |
+| Two-repo split: existing Next.js repo (backend changes) + new Expo repo (app) | Clean agent/ownership boundary; backend must stay backward-compatible forever |
+| Public API params/shape are append-only forever | Installed app versions will call old endpoints for years; breaking them breaks old installs silently |
+| Stable event IDs: one-time = DB cuid, recurring instance = `parentId-YYYY-MM-DD` (synthetic, not in DB) | Favorites and deep links depend on this resolving correctly for years |
+
+## 5. Architecture summary
+
+```
+Existing: Scrapers/AI ingest → Prisma/Postgres (Supabase) → Next.js API (/api/events) → Web
+
+New backend surface (same Next.js repo):
+  • GET  /api/events/[id]
+  • POST /api/devices            (push token registration)
+  • POST /api/push/tonight       (cron, sends daily notification)
+  • POST /api/push/send          (admin ad-hoc, e.g. emergencies)
+  • Device model (Prisma)
+                    │
+                    ▼
+New Expo iOS app (new repo, e.g. nyack-app/):
+  • expo-router (Today / Browse / Saved / More tabs)
+  • TanStack Query + AsyncStorage persister
+  • Zustand + AsyncStorage (device-local favorites, notification prefs)
+  • expo-notifications
+  • EAS Build/Submit/Update
+```
+
+No accounts anywhere in this diagram. Personalization = device state only.
+
+---
+
+## 6. Phase 0 — Foundations
+
+**Outcome:** Both repos can build, deploy, and talk to each other safely, with the one pre-existing security hole closed, before any user-facing screen exists.
+
+**Scope boundary:** No app screens beyond a scaffold. No push. No new user-facing behavior.
+
+### 6.1 Close the admin-auth gap (launch blocker — do this first, before anything else)
+
+- **Constraint:** Several `/api/admin/*` GET routes currently have no server-side auth and leak subscriber emails/submissions. This must be fixed before the app's existence draws any traffic to the domain, independent of the app itself.
+- **Task:** Apply the existing `checkAuth()` guard (pattern already used in `src/app/api/digest/route.ts`) to every unauthenticated `/api/admin/*` GET route.
+- **Verification:** `curl` each previously-open admin GET route without credentials → expect 401/403, not 200 with data. List the specific routes fixed in the PR description.
+
+### 6.2 Freeze the public API contract
+
+- **Task:** Write `docs/public-api.md` documenting every param and response field of `GET /api/events` and `GET /api/activities` as they exist today. Mark it "append-only" — new fields/params may be added, nothing removed or renamed.
+- **Verification:** Doc exists, checked into the Next.js repo, and the current live API's actual response is diffed against it (no undocumented fields).
+
+### 6.3 CORS wrapper for public read routes
+
+- **Task:** Add a CORS wrapper (`src/lib/api/response.ts` or equivalent) so the Expo app (different origin) can call `/api/events` and `/api/activities` directly.
+- **Verification:** A request from a non-web-app origin (e.g. `curl -H "Origin: exp://localhost"`) succeeds against the public read routes; write-routes and admin routes remain unaffected.
+
+### 6.4 Expo app scaffold
+
+- **Task:** New repo/directory. `expo-router` with four tabs (Today, Browse, Saved, More) as empty screens. Typed API client (`src/api/client.ts`, `src/types/api.ts`) hitting the **live production** `/api/events` (read-only — safe against prod).
+- **Verification:** App runs in Expo Go, all four tabs render, Today tab fetches and displays real event titles from production (visually confirm at least one real event name on screen).
+
+### 6.5 EAS project + TestFlight pipeline
+
+- **Task:** EAS project created, `eas.json` with three profiles (development/dev-client, preview/TestFlight, production). Apple Developer account enrolled (human step — flag to Danny, not delegable to the agent).
+- **Verification:** `eas build --profile preview` completes successfully and produces an installable build; build is submitted to TestFlight and installs on Danny's physical device.
+
+---
+
+## 7. Phase 1 — MVP: Events + "Tonight in Nyack" push
+
+**Outcome:** A resident can browse/search/filter events, save favorites that survive restarts and offline launches, see a real event detail screen, and receives a daily push naming tonight's best event that deep-links to it.
+
+**Scope boundary:** No accounts. No widget (Phase 1b). No news/alerts/utilities/business. No Android build.
+
+### 7.1 Backend: single-event endpoint
+
+- **Constraint:** Must handle the stable-ID contract (§4) — one-time cuid vs. synthetic recurring-instance ID `parentId-YYYY-MM-DD` — and 404 cleanly on a non-occurrence date rather than erroring.
+- **Task:** `src/app/api/events/[id]/route.ts`. Centralize ID parse/format logic as `getEventByStableId` in `src/lib/utils/events-query.ts` (single source of truth — do not duplicate parsing elsewhere). Reuse `generateRecurringInstances` from `src/lib/utils/recurrence.ts`. Same `Cache-Control` behavior as the list route.
+- **Verification (scriptable):**
+  - `curl /api/events/[one-time-cuid]` → 200, full event payload.
+  - `curl /api/events/[parentId]-[valid-future-date]` → 200, materialized instance.
+  - `curl /api/events/[parentId]-[date-with-no-occurrence]` → 404, not 500.
+  - Unit tests exist and pass for `getEventByStableId` covering all three cases above.
+
+### 7.2 Backend: Device model + registration endpoint
+
+- **Task:** Prisma migration adding `Device { id, expoPushToken @unique, platform, appVersion, wantsDailyTonight, wantsAlerts, alertMinSeverity, isActive, lastSeenAt, createdAt }`. `POST /api/devices` upserts by `expoPushToken` (idempotent — safe to call every app launch), validates token shape, rate-limited, no auth (device isn't logged in).
+- **Constraint:** Check Supabase RLS — confirm the anon key can reach `Device` appropriately (write access for registration, no broad read access to other devices' tokens).
+- **Verification:** `npx prisma migrate dev` + `npx prisma generate` succeed. Calling `POST /api/devices` twice with the same token results in one row, updated `lastSeenAt`, not two rows. Confirm via Prisma Studio or a direct query that RLS blocks reading other devices' tokens from the anon key.
+
+### 7.3 Backend: Tonight push (cron) + admin ad-hoc push
+
+- **Task:** `src/lib/push/send.ts` — Expo push fan-out via `expo-server-sdk`; handle `DeviceNotRegistered` receipts by flipping `Device.isActive = false`. `src/app/api/push/tonight/route.ts` — cron-authed (reuse the `CRON_SECRET` bearer-token pattern from the digest route), composes from `queryEvents({dateFilter: 'tonight'})`, optional one-line summary (reuse `generateWeeklySummary`'s gpt-4o-mini pattern), targets only devices with `wantsDailyTonight = true` and `isActive = true`. `src/app/api/push/send/route.ts` — admin-authed ad-hoc send (for manually firing an alert before Phase 2 exists). Add the cron to `vercel.json` alongside existing scrape/digest crons.
+- **Verification:**
+  - Local: `curl -H "Authorization: Bearer $CRON_SECRET" /api/push/tonight` fires correctly; confirm it selected tonight's actual top event and only targeted opted-in, active devices (log the count).
+  - On a physical device: register via the app, confirm the Expo token appears in the `Device` table, fire the cron manually, confirm the push arrives in foreground, background, and killed-app states.
+  - Tapping the push opens the app directly to the correct event detail screen (deep link), not just the Today tab.
+  - Send to a token that's since been deregistered → confirm `Device.isActive` flips to `false` and it's excluded from the next send.
+- **Content eval (not a unit test — a quality check):** Before shipping, build a golden set of ~10–15 known "tonight" event lists (including edge cases: zero events, one event, a free event, a paid event) and manually review the generated one-liner for each. Reject: hallucinated details not in the source event, tone inconsistent with the rest of the app, anything that reads as ad copy for a specific venue. This isn't scriptable pass/fail — it's a judgment review, budget 15 minutes for it before every model/prompt change to this pattern.
+
+### 7.4 App: Today / Browse / Saved tabs
+
+- **Task:** Today tab = tonight-first list (mirrors web's core UX). Browse tab = filters mirroring `/api/events` params (date, category, price, family-friendly) **plus free-text search**, which the web app currently lacks. Saved tab = device-local favorites via Zustand + AsyncStorage, keyed on the **stable event ID** (§4), not a synthetic per-render key.
+- **Verification:**
+  - Favoriting an event in Browse, then killing and relaunching the app, shows it still favorited in Saved.
+  - Turning on airplane mode and relaunching shows the last-cached event list within ~1 second (TanStack Query + AsyncStorage persister working), not a blank/error screen.
+  - Search returns correct results for a partial title match against a real production event.
+  - Favoriting a recurring event, then confirming it still resolves correctly if that specific date's instance is later requested via 7.1 above (cross-check with the ID contract, don't let this silently break).
+
+### 7.5 App: Event Detail screen
+
+- **Task:** New screen (the web app has none — its cards just deep-link out to source URLs). Full event info, add-to-calendar, share sheet, "favorite" toggle, deep-link target for both push notifications and universal links.
+- **Task (backend):** `public/.well-known/apple-app-site-association` for universal links, so a shared/tapped link opens the app (if installed) instead of the browser.
+- **Verification:** Opening a shared universal link on a device with the app installed opens the app directly to that event's detail screen, not Safari. Add-to-calendar produces a correct `.ics`/calendar entry with the right date/time in `America/New_York`.
+
+---
+
+## 8. Testing plan
+
+| Layer | Tool | What it covers |
+|---|---|---|
+| Unit | Jest | `getEventByStableId`, recurrence parsing, date/timezone utils, push receipt handling |
+| API contract | `curl` / a small script (or Vitest + supertest) | Every endpoint in §7.1–7.3, including error cases (404s, auth failures) |
+| App logic | Jest + React Native Testing Library | Favorites store, query client offline behavior, filter logic |
+| E2E (device flows) | Maestro (lighter weight than Detox for a solo dev) | Launch → browse → favorite → relaunch → still favorited; push tap → correct detail screen |
+| Manual/device-only | Physical iPhone + TestFlight | Push delivery in foreground/background/killed states; universal links from Safari/Messages; offline launch |
+
+**Gate rule for the agent:** nothing in §7 is "done" on the basis of code compiling or a static check. Each verification bullet must actually be run and its real output reported (curl output, test run output, or a description of what was observed on-device), per Phase. Treat a blocked permission (e.g. can't access a physical device) as a stop-and-ask signal, not something to route around or fake.
+
+## 9. Recommended multi-agent execution plan
+
+Given this is a two-repo project with a clean boundary, a simple three-role pattern works better than a single mega-session:
+
+- **Coordinator** — holds this PRD, breaks each Phase into the task-sized units already listed in §6–7, and doesn't write implementation code itself.
+- **Implementor(s)** — one per independent task where possible. Backend tasks (§7.1–7.3) and app tasks (§7.4–7.5) can run as separate sessions/sub-agents since they're different repos and don't share files, reducing merge conflicts.
+- **Verifier** — runs the verification bullets for a task before it's marked complete, and rejects back to the Implementor with specifics if a bullet fails. Don't let the Implementor self-certify its own task as done.
+
+Suggested session shape: one Coordinator session per Phase (0, then 1), spawning Implementor sub-agents per numbered subsection above, with the Verifier gate before moving to the next subsection. Phase 1's backend tasks (7.1–7.3) should complete and be verified before the app tasks that depend on them (7.4–7.5) start, since Browse/Saved/push all call those endpoints.
+
+## 10. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Stable ID contract breaks (recurring event reschedules, old favorited ID no longer resolves) | Centralize parsing in one helper (§7.1); show "event updated/removed" in-app rather than crashing |
+| Breaking the public API breaks old installed app versions silently | Treat `/api/events` params/shape as append-only forever (§4); version via new endpoints only |
+| Push is best-effort, not guaranteed delivery | Acceptable for MVP (not an emergency channel yet — that's Phase 2, with its own disclaimer requirement) |
+| App Store review flags this as a "thin web wrapper" (Guideline 4.2) | Native nav + offline cache + push + favorites give it enough native substance; Widget (1b) adds more if needed |
+| Admin auth gap (§6.1) | Fix before any app-driven traffic increase, independent of app timeline |
+
+## 11. Definition of done for the MVP
+
+- Phase 0 and Phase 1 verification criteria above all pass, with real output/evidence, not just "should work."
+- Internal TestFlight build installed on Danny's device (and any local testers').
+- Smoke test: offline launch shows cached events, Tonight push fires and deep-links correctly, favorites survive a restart, universal link from Safari opens the app.
+- No regressions on the live website or its public API (spot-check `/api/events` and `/api/activities` still return identical shape to `docs/public-api.md`).
+
+---
+
+## Appendix A — Deferred phases (not specced, one paragraph each)
+
+**Phase 1b (Widget):** WidgetKit/SwiftUI extension via `@bacons/apple-targets` Expo config plugin, sharing today's events through an App Group container. The one piece of real native Swift work in this project — needs EAS Build + a physical device, can't run in Expo Go. Sequenced after Phase 1's notification, same retention value, more native effort.
+
+**Phase 2 (News & Alerts):** `NewsItem` model + `AlertSeverity` enum, severity-filtered push reusing Phase 1's plumbing, ingestion from existing `nyackvillage.ts`/`patch.ts` scrapers. Needs an explicit in-app disclaimer ("not an official emergency channel") and admin kill-switch before shipping — liability-sensitive, do not rush.
+
+**Phase 3 (Utilities):** Trash/recycling calendar, parking rules, farmers-market schedule — mostly bundled JSON with an `AppConfig` override endpoint for fixing data without an app release. On-device local notification scheduling, no server push.
+
+**Phase 4 (Dining/Business):** New `Business` model (don't overload the existing `Activity` model's unstructured `hours` text) with structured hours/lat/lng/status, "open now" computed logic. Largest curation burden and closest to monetization — build last, write no monetization code until there's a concrete plan.
+
+## Appendix B — Open questions before an agent starts Phase 0
+
+- Is the Apple Developer account enrolled yet? (Human step, blocks EAS Submit.)
+- New repo name/location for the Expo app — confirmed as sibling repo, or nested in a `nyack-app/` directory?
+- Who owns tone/review of the Tonight push one-liner copy before it ships to testers?

--- a/prisma/add_device_table.sql
+++ b/prisma/add_device_table.sql
@@ -1,0 +1,21 @@
+-- Adds the Device table for iOS push-notification registration.
+-- Applied manually via the pooled connection (prisma db push uses DIRECT_URL,
+-- which is unreachable from this environment). Column/constraint/index names
+-- match Prisma's conventions so `prisma db push` sees the schema as in sync.
+
+CREATE TABLE IF NOT EXISTS "Device" (
+  "id" TEXT NOT NULL,
+  "expoPushToken" TEXT NOT NULL,
+  "platform" TEXT NOT NULL DEFAULT 'ios',
+  "appVersion" TEXT,
+  "wantsDailyTonight" BOOLEAN NOT NULL DEFAULT true,
+  "wantsAlerts" BOOLEAN NOT NULL DEFAULT true,
+  "alertMinSeverity" TEXT,
+  "isActive" BOOLEAN NOT NULL DEFAULT true,
+  "lastSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Device_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "Device_expoPushToken_key" ON "Device"("expoPushToken");
+CREATE INDEX IF NOT EXISTS "Device_isActive_idx" ON "Device"("isActive");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -174,6 +174,27 @@ model Subscriber {
   @@index([unsubscribeToken])
 }
 
+// Registered mobile devices for push notifications (iOS app).
+// Accountless: identity is the Expo push token. Preferences are stored here so
+// the backend can target sends without any user-account system.
+model Device {
+  id            String   @id @default(cuid())
+  expoPushToken String   @unique // "ExponentPushToken[...]"
+  platform      String   @default("ios")
+  appVersion    String?
+
+  // Notification opt-ins (mirrored from on-device settings)
+  wantsDailyTonight Boolean @default(true)
+  wantsAlerts       Boolean @default(true)  // Phase 2: news/emergency alerts
+  alertMinSeverity  String? // Phase 2: "INFO" | "ADVISORY" | "WARNING" | "EMERGENCY"
+
+  isActive      Boolean  @default(true) // flipped off on DeviceNotRegistered receipts
+  lastSeenAt    DateTime @default(now())
+  createdAt     DateTime @default(now())
+
+  @@index([isActive])
+}
+
 // Discord messages processed for event extraction
 model DiscordMessage {
   id              String   @id @default(cuid())

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,8 +1,20 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
+
+// The admin password is mirrored into a cookie scoped to /api/admin so the
+// browser sends it automatically on admin API calls, which src/middleware.ts
+// requires. Path-scoping keeps it off every other request to the origin.
+function setAdminCookie(password: string) {
+  const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : ''
+  document.cookie = `admin_password=${encodeURIComponent(password)}; Path=/api/admin; SameSite=Strict${secure}`
+}
+
+function clearAdminCookie() {
+  document.cookie = 'admin_password=; Path=/api/admin; Max-Age=0; SameSite=Strict'
+}
 
 export default function AdminLayout({
   children,
@@ -24,6 +36,14 @@ export default function AdminLayout({
   const [error, setError] = useState('')
   const pathname = usePathname()
 
+  // Ensure the cookie is present for already-authenticated sessions (page
+  // reloads, or sessions established before cookie auth was added).
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const storedPassword = sessionStorage.getItem('admin_password')
+    if (isAuthenticated && storedPassword) setAdminCookie(storedPassword)
+  }, [isAuthenticated])
+
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault()
     setError('')
@@ -38,6 +58,7 @@ export default function AdminLayout({
       if (response.ok) {
         sessionStorage.setItem('admin_auth', 'true')
         sessionStorage.setItem('admin_password', password)
+        setAdminCookie(password)
         setIsAuthenticated(true)
       } else {
         setError('Invalid password')
@@ -50,6 +71,7 @@ export default function AdminLayout({
   const handleLogout = () => {
     sessionStorage.removeItem('admin_auth')
     sessionStorage.removeItem('admin_password')
+    clearAdminCookie()
     setIsAuthenticated(false)
     setPassword('')
   }

--- a/src/app/api/devices/route.ts
+++ b/src/app/api/devices/route.ts
@@ -1,0 +1,113 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+/**
+ * Device registration for iOS push notifications.
+ *
+ * Accountless: the Expo push token is the identity. The app calls POST on every
+ * launch (idempotent upsert) and PATCH/DELETE when the user changes preferences.
+ * No auth — the token itself is the credential and only scopes push to that device.
+ */
+
+// Expo tokens look like "ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx]" (also the
+// legacy "ExpoPushToken[...]"). Reject anything else so we don't store junk.
+const EXPO_TOKEN_PATTERN = /^Expo(nent)?PushToken\[[^\]]+\]$/
+
+const VALID_SEVERITIES = ['INFO', 'ADVISORY', 'WARNING', 'EMERGENCY']
+
+function isValidToken(token: unknown): token is string {
+  return typeof token === 'string' && EXPO_TOKEN_PATTERN.test(token)
+}
+
+/**
+ * Collect the optional notification-preference fields present in a request body.
+ * Only keys that are actually provided are returned, so PATCH can do partial
+ * updates and POST can apply them on create/update.
+ */
+function extractPrefs(data: Record<string, unknown>) {
+  const prefs: Record<string, unknown> = {}
+  if (typeof data.platform === 'string') prefs.platform = data.platform
+  if (typeof data.appVersion === 'string') prefs.appVersion = data.appVersion
+  if (typeof data.wantsDailyTonight === 'boolean') prefs.wantsDailyTonight = data.wantsDailyTonight
+  if (typeof data.wantsAlerts === 'boolean') prefs.wantsAlerts = data.wantsAlerts
+  if (data.alertMinSeverity === null || VALID_SEVERITIES.includes(data.alertMinSeverity as string)) {
+    if ('alertMinSeverity' in data) prefs.alertMinSeverity = data.alertMinSeverity
+  }
+  return prefs
+}
+
+/**
+ * POST /api/devices
+ * Register or refresh a device. Idempotent upsert keyed on expoPushToken.
+ */
+export async function POST(request: NextRequest) {
+  try {
+    const data = await request.json().catch(() => ({}))
+    if (!isValidToken(data.expoPushToken)) {
+      return NextResponse.json({ error: 'Invalid or missing expoPushToken' }, { status: 400 })
+    }
+
+    const prefs = extractPrefs(data)
+    const device = await prisma.device.upsert({
+      where: { expoPushToken: data.expoPushToken },
+      // On refresh: reactivate (a token can come back after being pruned) and
+      // touch lastSeenAt, applying any preference changes sent along.
+      update: { ...prefs, isActive: true, lastSeenAt: new Date() },
+      create: { expoPushToken: data.expoPushToken, ...prefs },
+    })
+
+    return NextResponse.json({ device }, { status: 201 })
+  } catch (error) {
+    console.error('Device registration error:', error)
+    return NextResponse.json({ error: 'Failed to register device' }, { status: 500 })
+  }
+}
+
+/**
+ * PATCH /api/devices
+ * Update notification preferences for an already-registered device.
+ */
+export async function PATCH(request: NextRequest) {
+  try {
+    const data = await request.json().catch(() => ({}))
+    if (!isValidToken(data.expoPushToken)) {
+      return NextResponse.json({ error: 'Invalid or missing expoPushToken' }, { status: 400 })
+    }
+
+    const prefs = extractPrefs(data)
+    try {
+      const device = await prisma.device.update({
+        where: { expoPushToken: data.expoPushToken },
+        data: { ...prefs, lastSeenAt: new Date() },
+      })
+      return NextResponse.json({ device })
+    } catch {
+      return NextResponse.json({ error: 'Device not registered' }, { status: 404 })
+    }
+  } catch (error) {
+    console.error('Device update error:', error)
+    return NextResponse.json({ error: 'Failed to update device' }, { status: 500 })
+  }
+}
+
+/**
+ * DELETE /api/devices
+ * Deactivate a device (opt out of all push). Soft-delete so re-registration works.
+ */
+export async function DELETE(request: NextRequest) {
+  try {
+    const data = await request.json().catch(() => ({}))
+    if (!isValidToken(data.expoPushToken)) {
+      return NextResponse.json({ error: 'Invalid or missing expoPushToken' }, { status: 400 })
+    }
+
+    await prisma.device.updateMany({
+      where: { expoPushToken: data.expoPushToken },
+      data: { isActive: false },
+    })
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Device deactivation error:', error)
+    return NextResponse.json({ error: 'Failed to deactivate device' }, { status: 500 })
+  }
+}

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getEventByStableId } from '@/lib/utils/events-query'
+
+/**
+ * GET /api/events/[id]
+ * Fetch a single event by its stable id (as returned from /api/events).
+ *
+ * The id is either a one-time event cuid or a recurring occurrence of the form
+ * `${parentId}-${YYYY-MM-DD}`. Non-occurrence dates and hidden/missing events
+ * return 404. Clients (incl. the iOS app deep links) must treat the id as opaque.
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const event = await getEventByStableId(id)
+
+    if (!event) {
+      return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    }
+
+    const response = NextResponse.json({ event })
+    // Match the list route's caching so detail views stay cheap at the CDN.
+    response.headers.set('Cache-Control', 'public, s-maxage=60, stale-while-revalidate=300')
+    return response
+  } catch (error) {
+    console.error('Event detail API error:', error)
+    const message = error instanceof Error ? error.message : 'Unknown error'
+    return NextResponse.json({ error: 'Failed to fetch event', message }, { status: 500 })
+  }
+}

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { isAdminAuthorized } from '@/lib/auth'
+import { sendPushToDevices } from '@/lib/push/send'
+
+/**
+ * POST /api/push/send
+ * Admin-only ad-hoc push. Lets a human fire a one-off message (e.g. a snow
+ * emergency or road closure) before the structured News/Alerts system (Phase 2)
+ * exists. Requires the x-admin-password header.
+ *
+ * Body: { title, body, url?, audience? }
+ *   audience: "all" (default) → every active device
+ *             "alerts"        → devices with wantsAlerts=true
+ */
+export async function POST(request: NextRequest) {
+  if (!isAdminAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  try {
+    const data = await request.json().catch(() => ({}))
+    const { title, body, url, audience } = data
+
+    if (typeof title !== 'string' || !title.trim() || typeof body !== 'string' || !body.trim()) {
+      return NextResponse.json({ error: 'title and body are required' }, { status: 400 })
+    }
+
+    const where = audience === 'alerts' ? { wantsAlerts: true } : {}
+    const result = await sendPushToDevices(where, {
+      title,
+      body,
+      data: url ? { url, type: 'adhoc' } : { type: 'adhoc' },
+    })
+
+    console.log(`Ad-hoc push "${title}": ${result.sent} sent, ${result.failed} failed`)
+    return NextResponse.json(result)
+  } catch (error) {
+    console.error('Ad-hoc push error:', error)
+    return NextResponse.json({ error: 'Failed to send push' }, { status: 500 })
+  }
+}

--- a/src/app/api/push/tonight/route.ts
+++ b/src/app/api/push/tonight/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from 'next/server'
+import type { Event } from '@prisma/client'
+import { queryEvents } from '@/lib/utils/events-query'
+import { isCronOrAdminAuthorized } from '@/lib/auth'
+import { sendPushToDevices } from '@/lib/push/send'
+
+/**
+ * Daily "Tonight in Nyack" push — the app's headline retention feature.
+ *
+ * Triggered by Vercel cron (see vercel.json). Selects tonight's events with the
+ * same logic the web/app use (queryEvents), composes a short blurb, and fans out
+ * to devices that opted into the daily notification. Deep-links to the top event.
+ */
+
+async function generateTonightBlurb(events: Event[]): Promise<string> {
+  const top = events.slice(0, 5)
+  const fallback =
+    top.length === 1
+      ? `${top[0].title} at ${top[0].venue} tonight.`
+      : `${events.length} things happening in Nyack tonight — tap to see what's on.`
+
+  const apiKey = process.env.OPENAI_API_KEY
+  if (!apiKey) return fallback
+
+  try {
+    const OpenAI = (await import('openai')).default
+    const client = new OpenAI({ apiKey })
+    const list = top
+      .map((e) => `- ${e.title} at ${e.venue}${e.isFree ? ' (Free)' : ''}`)
+      .join('\n')
+
+    const response = await client.chat.completions.create({
+      model: 'gpt-4o-mini',
+      max_tokens: 120,
+      messages: [
+        {
+          role: 'user',
+          content: `Write a single punchy notification body (max ~140 chars, no emoji spam, at most one emoji) inviting Nyack, NY residents to tonight's events. Mention one specific event by name. Conversational and local, no generic filler.\n\nTonight:\n${list}`,
+        },
+      ],
+    })
+
+    return response.choices[0]?.message?.content?.trim() || fallback
+  } catch (error) {
+    console.error('Tonight blurb generation failed:', error)
+    return fallback
+  }
+}
+
+async function sendTonight() {
+  const events = await queryEvents({ dateFilter: 'tonight', limit: 10 })
+
+  if (events.length === 0) {
+    return NextResponse.json({ message: 'No events tonight — skipping push', sent: 0 })
+  }
+
+  const body = await generateTonightBlurb(events)
+  const result = await sendPushToDevices(
+    { wantsDailyTonight: true },
+    {
+      title: 'Tonight in Nyack 🌆',
+      body,
+      // Deep-link to the top event; the app opens the detail screen.
+      data: { url: `nyacktoday://event/${events[0].id}`, type: 'tonight' },
+    }
+  )
+
+  console.log(
+    `Tonight push: ${result.sent} sent, ${result.failed} failed, ${result.deactivated} pruned, ${events.length} events`
+  )
+  return NextResponse.json({ eventCount: events.length, ...result })
+}
+
+// Vercel cron uses GET; POST allows manual/admin triggering.
+export async function GET(request: NextRequest) {
+  if (!isCronOrAdminAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return sendTonight()
+}
+
+export async function POST(request: NextRequest) {
+  if (!isCronOrAdminAuthorized(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  return sendTonight()
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,36 @@
+import type { NextRequest } from 'next/server'
+
+/**
+ * Shared request authorization for admin and cron endpoints.
+ *
+ * Two shared secrets exist in this app (there is no per-user identity):
+ *  - ADMIN_PASSWORD, sent by the admin UI as the `x-admin-password` header.
+ *  - CRON_SECRET (legacy fallbacks DIGEST_CRON_SECRET / SCRAPER_API_KEY), sent by
+ *    Vercel cron as `Authorization: Bearer <secret>`.
+ *
+ * Previously each route re-implemented these checks (see api/digest/route.ts);
+ * this centralizes them so new routes stay consistent.
+ */
+
+/** True when the request carries the correct admin password header. */
+export function isAdminAuthorized(request: NextRequest): boolean {
+  const adminPassword = request.headers.get('x-admin-password')
+  return Boolean(process.env.ADMIN_PASSWORD && adminPassword === process.env.ADMIN_PASSWORD)
+}
+
+/** True when the request carries a valid Vercel cron bearer secret. */
+export function isCronAuthorized(request: NextRequest): boolean {
+  const cronSecret =
+    process.env.CRON_SECRET || process.env.DIGEST_CRON_SECRET || process.env.SCRAPER_API_KEY
+  const authHeader = request.headers.get('authorization')
+  return Boolean(cronSecret) && authHeader === `Bearer ${cronSecret}`
+}
+
+/**
+ * True for either an authenticated admin or a valid cron caller. Use for
+ * endpoints that both Vercel cron and a human admin may trigger (e.g. digests,
+ * scheduled pushes).
+ */
+export function isCronOrAdminAuthorized(request: NextRequest): boolean {
+  return isAdminAuthorized(request) || isCronAuthorized(request)
+}

--- a/src/lib/push/send.ts
+++ b/src/lib/push/send.ts
@@ -1,0 +1,119 @@
+import { prisma } from '@/lib/db'
+import type { Prisma } from '@prisma/client'
+
+/**
+ * Expo push fan-out.
+ *
+ * We POST directly to Expo's push service (no APNs integration required — Expo
+ * manages the APNs key). Modeled structurally on the webhook fan-out in
+ * src/lib/utils/notifications.ts. Dead tokens (DeviceNotRegistered) are pruned
+ * by flipping Device.isActive off so the list stays clean.
+ */
+
+const EXPO_PUSH_URL = 'https://exp.host/--/api/v2/push/send'
+const CHUNK_SIZE = 100 // Expo accepts up to 100 messages per request
+
+export interface PushMessage {
+  title: string
+  body: string
+  data?: Record<string, unknown>
+  sound?: 'default' | null
+}
+
+export interface PushResult {
+  sent: number
+  failed: number
+  deactivated: number
+}
+
+interface ExpoTicket {
+  status: 'ok' | 'error'
+  id?: string
+  message?: string
+  details?: { error?: string }
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
+/**
+ * Send a single message to an explicit list of Expo push tokens.
+ * Returns delivery counts and prunes tokens Expo reports as unregistered.
+ */
+export async function sendPushToTokens(
+  tokens: string[],
+  message: PushMessage
+): Promise<PushResult> {
+  const result: PushResult = { sent: 0, failed: 0, deactivated: 0 }
+  if (tokens.length === 0) return result
+
+  const deadTokens: string[] = []
+
+  for (const batch of chunk(tokens, CHUNK_SIZE)) {
+    const payload = batch.map((to) => ({
+      to,
+      title: message.title,
+      body: message.body,
+      data: message.data ?? {},
+      sound: message.sound === undefined ? 'default' : message.sound,
+    }))
+
+    try {
+      const res = await fetch(EXPO_PUSH_URL, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+
+      const json = (await res.json().catch(() => null)) as { data?: ExpoTicket[] } | null
+      const tickets = json?.data ?? []
+
+      batch.forEach((token, i) => {
+        const ticket = tickets[i]
+        if (ticket?.status === 'ok') {
+          result.sent++
+        } else {
+          result.failed++
+          if (ticket?.details?.error === 'DeviceNotRegistered') deadTokens.push(token)
+        }
+      })
+    } catch (error) {
+      console.error('Expo push batch failed:', error)
+      result.failed += batch.length
+    }
+  }
+
+  if (deadTokens.length > 0) {
+    const { count } = await prisma.device.updateMany({
+      where: { expoPushToken: { in: deadTokens } },
+      data: { isActive: false },
+    })
+    result.deactivated = count
+  }
+
+  return result
+}
+
+/**
+ * Send a message to every active device matching an optional preference filter.
+ * Pass e.g. { wantsDailyTonight: true } for the nightly digest.
+ */
+export async function sendPushToDevices(
+  where: Prisma.DeviceWhereInput,
+  message: PushMessage
+): Promise<PushResult> {
+  const devices = await prisma.device.findMany({
+    where: { isActive: true, ...where },
+    select: { expoPushToken: true },
+  })
+  return sendPushToTokens(
+    devices.map((d) => d.expoPushToken),
+    message
+  )
+}

--- a/src/lib/utils/events-query.ts
+++ b/src/lib/utils/events-query.ts
@@ -31,6 +31,53 @@ function deduplicateEvents(events: Event[]): Event[] {
   return deduplicated
 }
 
+// Recurring-instance stable ids are formatted as `${parentId}-${YYYY-MM-DD}` in
+// generateRecurringInstances(). cuids never contain hyphens, so a trailing
+// `-YYYY-MM-DD` unambiguously marks a recurring occurrence.
+const RECURRING_ID_PATTERN = /^(.+)-(\d{4}-\d{2}-\d{2})$/
+
+/**
+ * Resolve a single event by its stable id as returned from /api/events.
+ *
+ * Two id shapes are supported and must stay in sync with the ids emitted by
+ * queryEvents():
+ *  - A one-time event: the Prisma cuid.
+ *  - A recurring occurrence: `${parentId}-${YYYY-MM-DD}`, materialized on the fly.
+ *
+ * Returns null for hidden/missing events and for dates that are not a valid
+ * occurrence of a recurring event (callers should surface this as a 404).
+ */
+export async function getEventByStableId(stableId: string): Promise<Event | null> {
+  const match = stableId.match(RECURRING_ID_PATTERN)
+
+  if (match) {
+    const [, parentId, date] = match
+    const parent = await prisma.event.findUnique({ where: { id: parentId } })
+
+    if (parent && !parent.isHidden && parent.isRecurring) {
+      // Regenerate occurrences in a window around the target UTC day and match by
+      // exact id so we reuse the same synthesis logic that produced the id. The
+      // window spans +/- a day because the id suffix is the instance's UTC date,
+      // which can differ from its Eastern calendar date for late-evening events.
+      const target = new Date(`${date}T00:00:00.000Z`)
+      const rangeStart = new Date(target.getTime() - 24 * 60 * 60 * 1000)
+      const rangeEnd = new Date(target.getTime() + 2 * 24 * 60 * 60 * 1000)
+      const instance = generateRecurringInstances(parent, rangeStart, rangeEnd).find(
+        (i) => i.id === stableId
+      )
+      if (instance) return instance
+    }
+
+    // Matched the recurring shape but not a real occurrence — treat as not found
+    // rather than falling through to a (guaranteed-null) direct lookup.
+    return null
+  }
+
+  const event = await prisma.event.findUnique({ where: { id: stableId } })
+  if (!event || event.isHidden) return null
+  return event
+}
+
 export async function queryEvents(options: EventQueryOptions = {}): Promise<Event[]> {
   const {
     dateFilter,

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Server-side gate for all /api/admin/* routes.
+ *
+ * Historically these routes (stats, events, submissions, subscribers, etc.) had
+ * no server-side auth — only the client UI gated access — so subscriber emails
+ * and submissions were publicly reachable. This centralizes the check so every
+ * admin route is protected, including ones that don't check auth themselves.
+ *
+ * Accepted credentials (matching the rest of the app's shared-secret scheme):
+ *  - `admin_password` cookie (set by the admin UI at login, scoped to /api/admin
+ *    so the browser sends it automatically on every admin API call)
+ *  - `x-admin-password: <ADMIN_PASSWORD>` header (legacy admin UI calls)
+ *  - `Authorization: Bearer <ADMIN_PASSWORD>` (used by /api/admin/cleanup)
+ *  - `Authorization: Bearer <CRON_SECRET>` (Vercel cron)
+ *
+ * The login route (/api/admin/auth) is exempt — it verifies the password from
+ * the request body and must be reachable before the header can be set.
+ */
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (pathname === '/api/admin/auth') {
+    return NextResponse.next()
+  }
+
+  const adminPassword = process.env.ADMIN_PASSWORD
+  if (!adminPassword) {
+    // Fail closed rather than leaving admin data open when misconfigured.
+    return NextResponse.json({ error: 'Admin auth not configured' }, { status: 503 })
+  }
+
+  const cookiePassword = request.cookies.get('admin_password')?.value
+  const headerPassword = request.headers.get('x-admin-password')
+  const authHeader = request.headers.get('authorization')
+  const cronSecret =
+    process.env.CRON_SECRET || process.env.DIGEST_CRON_SECRET || process.env.SCRAPER_API_KEY
+
+  const authorized =
+    (cookiePassword !== undefined && decodeURIComponent(cookiePassword) === adminPassword) ||
+    headerPassword === adminPassword ||
+    authHeader === `Bearer ${adminPassword}` ||
+    (Boolean(cronSecret) && authHeader === `Bearer ${cronSecret}`)
+
+  if (!authorized) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/api/admin/:path*'],
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/digest",
       "schedule": "0 13 * * 4"
+    },
+    {
+      "path": "/api/push/tonight",
+      "schedule": "0 21 * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
## Summary

Backend foundations (Phase 0/1) for a resident-facing **Nyack iOS app** (Expo), built on the existing Nyack Today public API, plus a security fix for the admin routes. The app itself lives in a separate repo; this PR is the backend surface it consumes.

**iOS app backend**
- **`GET /api/events/[id]`** — public single-event endpoint. `getEventByStableId` (in `events-query.ts`) centralizes stable-id resolution for one-time cuids and recurring occurrences (`parentId-YYYY-MM-DD`), returning 404 on non-occurrence dates. Tested for all four cases.
- **`Device` model + `/api/devices`** — accountless push registration keyed on the Expo push token (upsert / prefs / deactivate; validates token shape). Table applied via `prisma/add_device_table.sql` (`prisma db push` can't reach `DIRECT_URL` from local).
- **Push** — `src/lib/push/send.ts` (Expo fan-out, prunes `DeviceNotRegistered` tokens), **`/api/push/tonight`** daily "Tonight in Nyack" cron, **`/api/push/send`** admin ad-hoc. Daily cron wired in `vercel.json` (21:00 UTC ≈ 4–5pm ET).
- **`src/lib/auth.ts`** — shared admin/cron auth helpers extracted from the digest route.
- **Docs** — `docs/public-api.md` (frozen public API contract), `docs/ios-app-setup.md` (Expo scaffolding guide), `ios-app-prd.md` (PRD).

**Security fix (separate commit)**
- **`src/middleware.ts`** gates every `/api/admin/*` route server-side. Previously these had no server-side auth — only the client UI gated them — so subscriber emails and submissions were publicly reachable. Accepts the `admin_password` cookie / `x-admin-password` header / Bearer secret, exempts the login route, and fails closed when `ADMIN_PASSWORD` is unset. The admin login mirrors the password into a cookie scoped to `/api/admin`, so no per-page fetch changes were needed.

## Test plan

- [x] `/api/events/[id]`: one-time id → 200, recurring occurrence → 200 (correct materialized instance), non-occurrence date → 404, invalid id → 404 (temp recurring event created + cleaned up).
- [x] `/api/devices`: create → 201, idempotent upsert, PATCH persists prefs, invalid token → 400, DELETE → 200.
- [x] `/api/push/tonight`: unauth → 401; authed → 200 (selected tonight's events, 0 active devices → no Expo call).
- [x] Admin gate: unauthenticated `/api/admin/stats` and `/api/admin/subscribers` → 401; header and cookie → 200; wrong password → 401; `/api/admin/auth` login still reachable.
- [x] `tsc --noEmit` clean for all new/changed files.
- [ ] **Manual smoke test recommended:** log into `/admin`, click Subscribers/Submissions/Events to confirm the dashboard still loads (verified at the HTTP layer; live click-through not automated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)