### PR TITLE
fix: rewrite Explore Rockland scraper to use native iCal feed

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,12 @@ const nextConfig: NextConfig = {
     '@discordjs/ws',
     'zlib-sync',
     'bufferutil',
-    'utf-8-validate'
+    'utf-8-validate',
+    'node-ical',
+    'rrule-temporal',
+    '@js-temporal/polyfill',
+    'temporal-polyfill',
+    'jsbi'
   ],
   turbopack: {
     root: __dirname,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "googleapis": "^171.4.0",
         "lucide-react": "^0.577.0",
         "next": "16.1.3",
+        "node-ical": "^0.26.1",
         "openai": "^6.25.0",
         "prisma": "^6.19.2",
         "puppeteer": "^24.38.0",
@@ -1699,6 +1700,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@js-temporal/polyfill": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.5.1.tgz",
+      "integrity": "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ==",
+      "license": "ISC",
+      "dependencies": {
+        "jsbi": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7048,6 +7061,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsbi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/jsbi/-/jsbi-4.3.2.tgz",
+      "integrity": "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew==",
+      "license": "Apache-2.0"
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7821,6 +7840,19 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-ical": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/node-ical/-/node-ical-0.26.1.tgz",
+      "integrity": "sha512-KoYLpsz7Ga9lPDpt9vy0iKcgcb/9Ix7ICRZd0csLXMl2lZOSONGj7HrcktJFR7Jid1l44Zu1H4k/1nB04rWPgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "rrule-temporal": "^1.5.3",
+        "temporal-polyfill": "^0.3.2"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/node-releases": {
@@ -8855,6 +8887,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rrule-temporal": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/rrule-temporal/-/rrule-temporal-1.6.0.tgz",
+      "integrity": "sha512-tlhiNroletItRVdVP3knk92MCPNdFmPpehQMxf+jSo0CHZpmp1WUsvdVpg2iS++J9+O7/89J64BldN21kbcBqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@js-temporal/polyfill": "^0.5.1",
+        "temporal-spec": "^1.0.0"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -9633,6 +9675,27 @@
       "dependencies": {
         "streamx": "^2.12.5"
       }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.2.tgz",
+      "integrity": "sha512-TzHthD/heRK947GNiSu3Y5gSPpeUDH34+LESnfsq8bqpFhsB79HFBX8+Z834IVX68P3EUyRPZK5bL/1fh437Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "0.3.1"
+      }
+    },
+    "node_modules/temporal-polyfill/node_modules/temporal-spec": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+      "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw==",
+      "license": "ISC"
+    },
+    "node_modules/temporal-spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-1.0.0.tgz",
+      "integrity": "sha512-00Ahj1e1ifaERTMOIIGpOCdOo9IEk2m6GGSMedsn9a2SIsGLdOTbmME1Htv6IM82b6VHrzSUTIVc7YHy6hdhFQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/text-decoder": {
       "version": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "googleapis": "^171.4.0",
     "lucide-react": "^0.577.0",
     "next": "16.1.3",
+    "node-ical": "^0.26.1",
     "openai": "^6.25.0",
     "prisma": "^6.19.2",
     "puppeteer": "^24.38.0",

--- a/src/lib/scrapers/explorerockland.ts
+++ b/src/lib/scrapers/explorerockland.ts
@@ -1,225 +1,108 @@
-import { Category } from '@prisma/client'
+import * as ical from 'node-ical'
 import { Scraper, ScraperResult, ScrapedEvent } from './types'
-import { parsePrice, guessFamilyFriendly } from './utils'
-import puppeteer from 'puppeteer-core'
-import type { Browser } from 'puppeteer-core'
-import chromium from '@sparticuz/chromium'
-import * as path from 'path'
+import { fetchWithTimeout, guessFamilyFriendly } from './utils'
+import { guessCategory } from '@/lib/utils/categories'
 
 const SOURCE_NAME = 'Explore Rockland'
-const SOURCE_URL = 'https://explorerocklandny.com/events'
+const ICAL_URL = 'https://explorerocklandny.com/?post_type=tribe_events&ical=1&eventDisplay=list'
 
 // Cities we care about
 const ALLOWED_CITIES = ['nyack', 'west nyack', 'upper nyack']
 
 /**
- * Guess event category based on title and description
+ * node-ical returns string fields as either a plain string or, when the
+ * property has ICS parameters (e.g. ATTACH;FMTTYPE=...), an object with a
+ * `val` property.
  */
-function guessCategory(title: string, description: string): Category {
-  const combined = `${title} ${description}`.toLowerCase()
-
-  if (combined.match(/\b(concert|music|jazz|band|singer|guitar|piano|orchestra)\b/i)) {
-    return Category.MUSIC
+function paramValue(value: unknown): string | null {
+  if (typeof value === 'string') return value
+  if (value && typeof value === 'object' && 'val' in value) {
+    return String((value as { val: unknown }).val)
   }
-  if (combined.match(/\b(comedy|comedian|stand-up|improv|funny)\b/i)) {
-    return Category.COMEDY
-  }
-  if (combined.match(/\b(movie|film|cinema|screening)\b/i)) {
-    return Category.MOVIES
-  }
-  if (combined.match(/\b(play|theater|theatre|musical|performance|show)\b/i)) {
-    return Category.THEATER
-  }
-  if (combined.match(/\b(kids|children|family|families|youth)\b/i)) {
-    return Category.FAMILY_KIDS
-  }
-  if (combined.match(/\b(restaurant|dining|food|wine|tasting|culinary|cooking)\b/i)) {
-    return Category.FOOD_DRINK
-  }
-  if (combined.match(/\b(sports|athletic|fitness|race|marathon|game)\b/i)) {
-    return Category.SPORTS_RECREATION
-  }
-  if (combined.match(/\b(art|gallery|exhibition|museum|painting|sculpture)\b/i)) {
-    return Category.ART_GALLERIES
-  }
-  if (combined.match(/\b(class|workshop|seminar|course|training|lesson)\b/i)) {
-    return Category.CLASSES_WORKSHOPS
-  }
-  if (combined.match(/\b(meeting|council|government|town hall|public)\b/i)) {
-    return Category.COMMUNITY_GOVERNMENT
-  }
-
-  return Category.OTHER
+  return null
 }
 
 /**
- * Scraper for Explore Rockland events calendar
- * Uses Puppeteer to handle JavaScript-rendered content
+ * Scraper for Explore Rockland events.
+ *
+ * The site's WordPress "The Events Calendar" plugin publishes a native iCal
+ * feed (the same one powering its "Add to Google Calendar" link), so we
+ * parse that directly instead of scraping the rendered calendar page. No
+ * headless browser needed.
  */
 export const exploreRocklandScraper: Scraper = {
   name: SOURCE_NAME,
 
   async scrape(): Promise<ScraperResult> {
     const events: ScrapedEvent[] = []
-    let browser: Browser | null = null
 
     try {
-      // Launch Puppeteer with appropriate config for environment
-      const isVercel = !!process.env.VERCEL_ENV
-
-      if (isVercel) {
-        // Vercel/serverless: use @sparticuz/chromium
-
-        // Set runtime (fallback if not in Vercel Dashboard)
-        if (!process.env.AWS_LAMBDA_JS_RUNTIME) {
-          process.env.AWS_LAMBDA_JS_RUNTIME = 'nodejs22.x'
+      const response = await fetchWithTimeout(ICAL_URL, 15000)
+      if (!response.ok) {
+        return {
+          sourceName: SOURCE_NAME,
+          events: [],
+          status: 'error',
+          errorMessage: `HTTP ${response.status}: ${response.statusText}`,
         }
-
-        // Get executable path and set library path
-        const executablePath = await chromium.executablePath()
-        const execDir = path.dirname(executablePath)
-
-        // CRITICAL: Set LD_LIBRARY_PATH so Chromium can find libraries
-        process.env.LD_LIBRARY_PATH = execDir
-
-        browser = await puppeteer.launch({
-          args: chromium.args,
-          executablePath,
-          headless: true,
-        })
-      } else {
-        // Local development: use Puppeteer's Chrome
-        // You can set CHROME_BIN env var to override
-        const executablePath = process.env.CHROME_BIN ||
-          '/Users/danielfenjves/.cache/puppeteer/chrome/mac_arm-146.0.7680.31/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing'
-
-        browser = await puppeteer.launch({
-          args: ['--no-sandbox', '--disable-setuid-sandbox'],
-          executablePath,
-          headless: true,
-        })
       }
 
-      const page = await browser.newPage()
-      await page.setUserAgent(
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-      )
+      const icsText = await response.text()
+      const calendar = ical.sync.parseICS(icsText)
+      const now = new Date()
 
-      // Navigate to events page
-      await page.goto(SOURCE_URL, {
-        waitUntil: 'networkidle2',
-        timeout: 30000,
-      })
+      for (const component of Object.values(calendar)) {
+        if (!component || component.type !== 'VEVENT') continue
 
-      // Wait for events to load
-      await page.waitForSelector('.tribe-events-calendar-list__event-row', {
-        timeout: 10000,
-      })
+        const title = paramValue(component.summary)
+        const location = paramValue(component.location)
+        const startDate = component.start ? new Date(component.start) : null
 
-      // Extract event data from the page
-      const eventData = await page.evaluate(() => {
-        const eventElements = Array.from(
-          document.querySelectorAll('.tribe-events-calendar-list__event-row')
-        )
+        if (!title || !location || !startDate || isNaN(startDate.getTime())) continue
 
-        return eventElements.map((event) => {
-          const titleEl = event.querySelector('.tribe-events-calendar-list__event-title-link')
-          const dateEl = event.querySelector('.tribe-events-calendar-list__event-datetime')
-          const venueEl = event.querySelector('.tribe-events-calendar-list__event-venue-title')
-          const addressEl = event.querySelector('.tribe-events-calendar-list__event-venue-address')
-          const descEl = event.querySelector('.tribe-events-calendar-list__event-description')
-          const costEl = event.querySelector('.tribe-events-calendar-list__event-cost')
-
-          return {
-            title: titleEl?.textContent?.trim() || '',
-            url: (titleEl as HTMLAnchorElement)?.href || '',
-            dateTime: dateEl?.getAttribute('datetime') || '',
-            venue: venueEl?.textContent?.trim() || '',
-            address: addressEl?.textContent?.trim() || '',
-            description: descEl?.textContent?.trim() || '',
-            cost: costEl?.textContent?.trim() || '',
-          }
-        })
-      })
-
-      // Process and filter events
-      for (const event of eventData) {
         // Filter by city - only include Nyack, West Nyack, Upper Nyack
-        if (!event.address) continue
-
-        const addressLower = event.address.toLowerCase()
-        const isNyackArea = ALLOWED_CITIES.some((city) => addressLower.includes(city))
-
-        if (!isNyackArea) {
-          continue // Skip events outside our target cities
-        }
-
-        // Parse date
-        let startDate: Date
-        try {
-          if (event.dateTime) {
-            startDate = new Date(event.dateTime)
-          } else {
-            continue // Skip if no date
-          }
-        } catch {
-          continue // Skip if date parsing fails
-        }
+        const locationLower = location.toLowerCase()
+        const isNyackArea = ALLOWED_CITIES.some((city) => locationLower.includes(city))
+        if (!isNyackArea) continue
 
         // Skip past events
-        const now = new Date()
-        if (startDate < now) {
-          continue
-        }
+        if (startDate < now) continue
 
         // Determine city
         let city = 'Nyack'
         let isNyackProper = true
-        if (addressLower.includes('west nyack')) {
+        if (locationLower.includes('west nyack')) {
           city = 'West Nyack'
           isNyackProper = false
-        } else if (addressLower.includes('upper nyack')) {
+        } else if (locationLower.includes('upper nyack')) {
           city = 'Upper Nyack'
           isNyackProper = false
         }
 
-        // Parse price
-        let price: string | null = null
-        let isFree = false
-        if (event.cost) {
-          const parsed = parsePrice(event.cost)
-          price = parsed.price
-          isFree = parsed.isFree
-        }
-
-        // Guess category from title and description
-        const category = guessCategory(event.title, event.description)
-
-        // Determine if family friendly
-        const isFamilyFriendly = guessFamilyFriendly(event.title, event.description)
+        const venue = location.split(',')[0].trim() || 'Rockland County'
+        const description = paramValue(component.description)?.trim() || null
+        const imageUrl = paramValue(component.attach)
 
         const scrapedEvent: ScrapedEvent = {
-          title: event.title,
-          description: event.description || null,
+          title,
+          description,
           startDate,
-          endDate: null,
-          venue: event.venue || 'Rockland County',
-          address: event.address,
+          endDate: component.end ? new Date(component.end) : null,
+          venue,
+          address: location,
           city,
           isNyackProper,
-          category,
-          price,
-          isFree,
-          isFamilyFriendly,
-          sourceUrl: event.url || SOURCE_URL,
+          category: guessCategory(title, description),
+          price: null,
+          isFree: false,
+          isFamilyFriendly: guessFamilyFriendly(title, description),
+          sourceUrl: component.url || ICAL_URL,
           sourceName: SOURCE_NAME,
-          imageUrl: null,
+          imageUrl,
         }
 
         events.push(scrapedEvent)
       }
-
-      await browser.close()
 
       if (events.length === 0) {
         return {
@@ -236,10 +119,6 @@ export const exploreRocklandScraper: Scraper = {
         status: 'success',
       }
     } catch (error) {
-      if (browser) {
-        await browser.close()
-      }
-
       const message = error instanceof Error ? error.message : 'Unknown error'
       return {
         sourceName: SOURCE_NAME,


### PR DESCRIPTION
## Summary
- Every production run of the Explore Rockland scraper was failing with the same error: `The input directory "/var/task/node_modules/@sparticuz/chromium/bin" does not exist. Please provide the location of the brotli files.` — confirmed via `ScraperLog` history going back weeks, and the same error hits `Scott & Joe` (the only other Puppeteer scraper), so it's a Vercel/`@sparticuz/chromium` bundling issue, not a site problem.
- The site's WordPress "The Events Calendar" plugin publishes a native iCal feed (the same one backing its "Add to Google Calendar" link), so the scraper now fetches and parses that directly with `node-ical` instead of driving a headless browser.
- Drops the Puppeteer/`@sparticuz/chromium` dependency for this source entirely — no CSS selectors to break, no serverless Chrome to bundle.

## Test plan
- [x] Ran the rewritten scraper directly against the live feed — returned 8 correctly filtered/categorized Nyack-area events (city filtering and date filtering verified).
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint src/lib/scrapers/explorerockland.ts` — clean
- [ ] Confirm a scheduled production run succeeds and events land in the DB

## Known tradeoff
The iCal feed doesn't expose ticket price, so `price`/`isFree` are now unset for this source (previously scraped from a cost element on the page). Reliability gain seemed worth it — happy to add per-event page fetches for pricing if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)