### PR TITLE
Add duplicate event action to admin dashboard

### DIFF
--- a/src/app/admin/events/page.tsx
+++ b/src/app/admin/events/page.tsx
@@ -2,18 +2,20 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Event } from '@prisma/client'
 import { categoryLabels } from '@/lib/utils/categories'
 import { Category } from '@prisma/client'
 import { decodeHtmlEntities } from '@/lib/utils/text'
 
 export default function AdminEventsPage() {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const showHidden = searchParams.get('hidden') === 'true'
 
   const [events, setEvents] = useState<Event[]>([])
   const [loading, setLoading] = useState(true)
+  const [duplicatingId, setDuplicatingId] = useState<string | null>(null)
   const [filter, setFilter] = useState<'all' | 'upcoming' | 'past' | 'hidden'>(
     showHidden ? 'hidden' : 'upcoming'
   )
@@ -86,6 +88,28 @@ export default function AdminEventsPage() {
       }
     } catch (error) {
       console.error('Failed to delete event:', error)
+    }
+  }
+
+  const duplicateEvent = async (event: Event) => {
+    setDuplicatingId(event.id)
+    try {
+      const response = await fetch(
+        `/api/admin/events/${event.id}/duplicate`,
+        { method: 'POST' }
+      )
+
+      if (response.ok) {
+        const data = await response.json()
+        // Land on the copy's edit page so the date/details can be adjusted.
+        // The copy is hidden until saved from there.
+        router.push(`/admin/events/${data.event.id}`)
+      } else {
+        setDuplicatingId(null)
+      }
+    } catch (error) {
+      console.error('Failed to duplicate event:', error)
+      setDuplicatingId(null)
     }
   }
 
@@ -222,6 +246,13 @@ export default function AdminEventsPage() {
                       >
                         Edit
                       </Link>
+                      <button
+                        onClick={() => duplicateEvent(event)}
+                        disabled={duplicatingId === event.id}
+                        className="px-3 py-1 bg-blue-100 text-blue-700 text-xs rounded font-medium hover:bg-blue-200 disabled:opacity-50 transition-colors"
+                      >
+                        {duplicatingId === event.id ? 'Duplicating…' : 'Duplicate'}
+                      </button>
                       <button
                         onClick={() => deleteEvent(event)}
                         className="px-3 py-1 bg-red-100 text-red-700 text-xs rounded font-medium hover:bg-red-200 transition-colors"

--- a/src/app/api/admin/events/[id]/duplicate/route.ts
+++ b/src/app/api/admin/events/[id]/duplicate/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/db'
+
+/**
+ * POST /api/admin/events/[id]/duplicate
+ * Create a copy of an existing event. The copy is hidden by default so it
+ * doesn't publish with the original's date before an admin adjusts it.
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+
+    const original = await prisma.event.findUnique({
+      where: { id },
+    })
+
+    if (!original) {
+      return NextResponse.json(
+        { error: 'Event not found' },
+        { status: 404 }
+      )
+    }
+
+    const event = await prisma.event.create({
+      data: {
+        title: original.title,
+        description: original.description,
+        startDate: original.startDate,
+        endDate: original.endDate,
+        venue: original.venue,
+        address: original.address,
+        city: original.city,
+        isNyackProper: original.isNyackProper,
+        category: original.category,
+        price: original.price,
+        isFree: original.isFree,
+        isFamilyFriendly: original.isFamilyFriendly,
+        sourceUrl: original.sourceUrl,
+        sourceName: original.sourceName,
+        imageUrl: original.imageUrl,
+        isMarquee: original.isMarquee,
+        isRecurring: original.isRecurring,
+        recurrenceDays: original.recurrenceDays,
+        recurrenceEndDate: original.recurrenceEndDate,
+        // Hidden by default so the copy isn't publicly listed until reviewed.
+        isHidden: true,
+        // sourceHash is unique and is left null to avoid a constraint clash.
+        sourceHash: null,
+      },
+    })
+
+    return NextResponse.json({ event }, { status: 201 })
+  } catch (error) {
+    console.error('Duplicate event error:', error)
+    return NextResponse.json(
+      { error: 'Failed to duplicate event' },
+      { status: 500 }
+    )
+  }
+}


### PR DESCRIPTION
## Summary

Adds the ability to duplicate an event from the admin dashboard. Each row in the admin events list gets a **Duplicate** button (between Edit and Delete). Clicking it clones the event server-side and drops the admin onto the copy's edit page to adjust the date/details.

## Changes

- **`src/app/api/admin/events/[id]/duplicate/route.ts`** (new): `POST` endpoint that clones an event, copying every field including image, marquee flag, and recurrence settings.
- **`src/app/admin/events/page.tsx`**: New "Duplicate" button + handler that calls the endpoint and redirects to the new copy's edit page (with a "Duplicating…" loading state).

## Behavior notes

- **The copy is hidden by default.** A duplicate usually means "same event, new date," so publishing it immediately would list a wrong-dated duplicate publicly. It stays hidden until saved from the edit page (where the "Hide event" checkbox can un-hide it).
- **`sourceHash` is nulled on the copy.** That field is `@unique` in the schema (scraper dedup), so copying it verbatim would trigger a constraint error.

## Testing

- `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01A8RCbnpLtj6k3u1kXu8W8T)_