### PR TITLE
Fix event dedup for generic venues and series subtitles

### DIFF
--- a/.claude/hooks/check-claude-md.sh
+++ b/.claude/hooks/check-claude-md.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Stop hook: nudges Claude to review/update CLAUDE.md when files it documents
+# have changed but CLAUDE.md itself hasn't been touched in the same working
+# tree state. Fires at most once per distinct set of relevant changes so it
+# can't loop forever if Claude decides no update is needed.
+
+set -euo pipefail
+
+session_id=$(jq -r '.session_id // "unknown"')
+
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+cd "$repo_root"
+
+# Patterns for files whose changes typically require a CLAUDE.md update:
+# commands, architecture, data model, key files, scraper tiers, design system.
+relevant_files=$(git status --porcelain -- \
+  'package.json' \
+  'prisma/schema.prisma' \
+  'src/lib/scrapers/' \
+  'src/lib/db.ts' \
+  'src/lib/utils/dates.ts' \
+  'src/lib/utils/categories.ts' \
+  'data-sources.md' \
+  'src/app/globals.css' \
+  2>/dev/null | awk '{print $2}' | sort)
+
+if [ -z "$relevant_files" ]; then
+  exit 0
+fi
+
+# If CLAUDE.md is already part of the current changes, assume it's been
+# considered as part of this diff.
+if git status --porcelain -- 'CLAUDE.md' 2>/dev/null | grep -q .; then
+  exit 0
+fi
+
+hash=$(printf '%s' "$relevant_files" | shasum -a 1 | awk '{print $1}')
+sentinel="/tmp/claude-md-nudge-${session_id}"
+
+if [ -f "$sentinel" ] && [ "$(cat "$sentinel")" = "$hash" ]; then
+  exit 0
+fi
+
+echo "$hash" > "$sentinel"
+
+file_list=$(printf '%s\n' "$relevant_files" | sed 's/^/- /')
+
+reason="Files that CLAUDE.md documents have changed in the working tree, but CLAUDE.md itself wasn't updated:
+${file_list}
+
+Check whether CLAUDE.md's Commands, Architecture, Data Model, Key Files, Scraper Tiers, or Design System sections are now stale, and update them if so. If nothing in CLAUDE.md actually needs to change, just say so briefly."
+
+jq -n --arg reason "$reason" '{decision: "block", reason: $reason}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-claude-md.sh 2>/dev/null || true",
+            "statusMessage": "Checking CLAUDE.md freshness..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/lib/scrapers/utils.ts
+++ b/src/lib/scrapers/utils.ts
@@ -82,6 +82,16 @@ export function normalizeTitle(title: string, venue?: string): string {
   // Strip parenthetical content (e.g. "(benefitting The Angel)", "(outdoor)")
   normalized = normalized.replace(/\s*\([^)]*\)/g, '').trim()
 
+  // Truncate at act/subtitle separators. Recurring series are often listed as
+  // "Series Name Presents: Specific Act" by one source and just "Series Name"
+  // by another (e.g. "Music on the Hudson Presents: Dead Meat" vs "Music on
+  // the Hudson Summer Concert Series") — keep only the series name so the two
+  // forms normalize to a comparable prefix.
+  const subtitleSeparator = normalized.match(/\b(presents|featuring|feat\.?|ft\.?)\b/i)
+  if (subtitleSeparator && subtitleSeparator.index) {
+    normalized = normalized.substring(0, subtitleSeparator.index).trim()
+  }
+
   // Remove common prefixes
   for (const prefix of prefixes) {
     if (normalized.startsWith(prefix)) {
@@ -205,14 +215,20 @@ export function areEventsDuplicates(
     return false
   }
 
-  // Venues must be similar
+  // Venues must be similar — unless one side is just a bare city/area name
+  // (e.g. "Nyack"), which some sources use as a fallback when they can't
+  // extract a specific venue. That's not real venue information, so it
+  // shouldn't be able to veto a match against a source with a precise venue.
   const normalizedVenue1 = normalizeVenue(venue1)
   const normalizedVenue2 = normalizeVenue(venue2)
-  const venueSimilarity = stringSimilarity(normalizedVenue1, normalizedVenue2)
+  const venue1IsGenericCity = nearbyCities.includes(normalizedVenue1)
+  const venue2IsGenericCity = nearbyCities.includes(normalizedVenue2)
 
-  // If venues are very different, not duplicates
-  if (venueSimilarity < 0.7) {
-    return false
+  if (!venue1IsGenericCity && !venue2IsGenericCity) {
+    const venueSimilarity = stringSimilarity(normalizedVenue1, normalizedVenue2)
+    if (venueSimilarity < 0.7) {
+      return false
+    }
   }
 
   // Check title similarity


### PR DESCRIPTION
## Summary
- Fixes false-negative duplicate detection when one source falls back to a generic city name (e.g. "Nyack") instead of a real venue, which was blocking fuzzy matches against sources with precise venue names.
- Fixes title matching for recurring series listed as "Series Name Presents: Specific Act" by one source vs just "Series Name" by another.
- Fixes the "Music on the Hudson" event showing up twice (once from Nyack News and Views, once from Explore Rockland) and manually removed the stale duplicate row from the database.
- Adds a Stop hook (`.claude/hooks/check-claude-md.sh`) that nudges a review of CLAUDE.md when files it documents change without CLAUDE.md being updated in the same diff.

## Test plan
- [x] Verified `areEventsDuplicates` now returns `true` for the actual Music on the Hudson duplicate pair, and still `false` for the same title/venue on a different week (July 28)
- [x] Verified unrelated same-day events at two distinct real venues still don't dedupe
- [x] Verified edge cases for the new title-truncation regex (leading "Presents", "ft."/"feat." forms)
- [x] Pipe-tested the Stop hook against synthetic stdin payloads; validated JSON schema with `jq -e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)